### PR TITLE
fix: validate restore paths before writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,6 @@ Screwdriver restores files from fenced code blocks whose opening line starts wit
 > [!IMPORTANT]
 > Restore only from notes you trust. Screwdriver writes files to paths recorded in the note.
 
+Restore paths must be canonical, portable Vault-relative paths using `/` separators. Screwdriver skips absolute paths, parent traversal, backslashes, empty path components, control characters, and names that are invalid or reserved on common desktop platforms. When `adjustObsidianDir` is enabled, the portable `.obsidian/` prefix is validated and mapped below the active Vault configuration directory.
+
 Screwdriver can be useful with [Self-hosted LiveSync](https://github.com/vrtmrz/obsidian-livesync) or [remotely-save](https://github.com/fyears/remotely-save) when you want to sync configuration files between devices.

--- a/docs/devs.md
+++ b/docs/devs.md
@@ -32,7 +32,7 @@ Scripted responses are instance-scoped. Call `assertDone()` so an expected inter
 
 ## Fancy Kit preview
 
-Until Fancy Kit is published to npm, its packages are pinned to immutable tarballs from one GitHub prerelease. Update the UI interactions and Obsidian plug-in kit URLs together when a migration needs a newer preview.
+Until Fancy Kit is published to npm, its packages are pinned to immutable tarballs from one GitHub prerelease. Update all Fancy Kit package URLs used by the plug-in together when a migration needs a newer preview. The restore path boundary currently consumes the OW prerelease from the same preview tag.
 
 The App-free tests verify workflow policy and the UI transcript. They do not replace real Obsidian coverage for modal rendering, keyboard handling, focus, or theme behaviour.
 
@@ -41,6 +41,15 @@ The local-only real-Obsidian scenario installs the production build into an isol
 ```bash
 npm run check:e2e:obsidian
 npm run test:e2e:obsidian:add-target
+npm run test:e2e:obsidian:restore-paths
 ```
 
 Real-Obsidian E2E is currently validated on Linux only and is not part of the default CI gate.
+
+## Restore path boundary
+
+Paths parsed from fenced block headers are untrusted input. `restore-path.ts` uses `octagonal-wheels/path` to accept only canonical portable relative paths before any Vault adapter `stat`, directory creation, or write operation.
+
+With `adjustObsidianDir` enabled, a validated `.obsidian/` suffix is resolved below the trusted `vault.configDir`. Other paths remain Vault-relative. Unsafe input is skipped rather than normalised; this prevents absolute paths, parent traversal, backslash variants, empty components, control characters, and portable-invalid names from changing meaning on another platform.
+
+The App-free suite owns the path policy contract. The local real-Obsidian restore scenario verifies that a safe block is written inside the isolated Vault while an unsafe sibling traversal is not written outside it.

--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,8 @@
 import { createObsidianUi, type UiInteractions } from "@vrtmrz/obsidian-plugin-kit/ui";
+import { UnsafePathError } from "octagonal-wheels/path";
 import { App, Editor, MarkdownView, Notice, parseYaml, Plugin, requestUrl, arrayBufferToBase64, base64ToArrayBuffer, MarkdownRenderer, TFile, type MarkdownFileInfo, MarkdownRenderChild } from "obsidian";
+import { PORTABLE_OBSIDIAN_CONFIG_DIR, resolveRestorePath } from "./restore-path";
 import { chooseTargetDirectory, shouldIncludePluginData } from "./ui-workflow";
-// eslint-disable-next-line obsidianmd/hardcoded-config-path -- This is not actually used. used as an pseudo name.
-const DEFAULT_OBSIDIAN_DIR = ".obsidian";
 // Util functions
 async function getFiles(
 	app: App,
@@ -257,7 +257,7 @@ export default class ScrewDriverPlugin extends Plugin {
 							stat.mtime
 						).toLocaleString()} \n`;
 						const writeFileName = (adjustObsidianDir && file.startsWith(this.app.vault.configDir))
-							? DEFAULT_OBSIDIAN_DIR + file.substring(this.app.vault.configDir.length) : file;
+							? PORTABLE_OBSIDIAN_CONFIG_DIR + file.substring(this.app.vault.configDir.length) : file;
 						newData += "\n```screwdriver:" + writeFileName + ":" + (bin ? "bin" : "plain") + ":" + stat.mtime + "\n";
 						newData += fileDat + "";
 						newData += "\n```";
@@ -308,10 +308,18 @@ export default class ScrewDriverPlugin extends Plugin {
 						for (const preBlock of preBlocks) {
 							const [, filenameSrc, data] = preBlock;
 							const [filenameData, dataType, mtimeStr] = `${filenameSrc}:`.split(":");
-							const filename =
-								(adjustObsidianDir && filenameData.startsWith(DEFAULT_OBSIDIAN_DIR + "/"))
-									? filenameData.replace(DEFAULT_OBSIDIAN_DIR, this.app.vault.configDir)
-									: filenameData;
+							let filename: string;
+							try {
+								filename = resolveRestorePath({
+									storedPath: filenameData,
+									configDir: this.app.vault.configDir,
+									adjustObsidianDir,
+								});
+							} catch (error) {
+								if (!(error instanceof UnsafePathError)) throw error;
+								new Notice(`Skipped unsafe restore path ${JSON.stringify(error.input)} (${error.reason}).`);
+								continue;
+							}
 
 							let saveData = data;
 							try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,16 @@
 			"version": "0.0.11",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
-				"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz"
+				"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
+				"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-ui-interactions-0.0.0.tgz",
+				"octagonal-wheels": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/octagonal-wheels-0.1.47-preview.0.tgz"
 			},
 			"devDependencies": {
 				"@emnapi/core": "1.11.2",
 				"@emnapi/runtime": "1.11.2",
 				"@types/node": "^22.15.3",
 				"@typescript-eslint/parser": "^8.31.1",
-				"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
+				"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-obsidian-test-session-0.0.0.tgz",
 				"esbuild": "0.28.1",
 				"eslint": "^9.25.1",
 				"eslint-plugin-obsidianmd": "^0.3.0",
@@ -1617,7 +1618,7 @@
 		},
 		"node_modules/@vrtmrz/obsidian-plugin-kit": {
 			"version": "0.0.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
 			"integrity": "sha512-nWPtnxO7wImPmANjSHlka1o62X/MQScCVvmegYtG0jW56fNPUvzLF5cd86RJUdUcTZsgXrk6s3d3N2SdXOR5Xw==",
 			"license": "MIT",
 			"dependencies": {
@@ -1629,7 +1630,7 @@
 		},
 		"node_modules/@vrtmrz/obsidian-test-session": {
 			"version": "0.0.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-obsidian-test-session-0.0.0.tgz",
 			"integrity": "sha512-XHWFORR8Q7vQsbKxrj8RBgpyC7DHFw5PSUXkBOKJoHnx9abgCkuQp4gYYa64RO7sOdRx/Xj799JOop+McQSqsg==",
 			"dev": true,
 			"license": "MIT",
@@ -1642,7 +1643,7 @@
 		},
 		"node_modules/@vrtmrz/ui-interactions": {
 			"version": "0.0.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-ui-interactions-0.0.0.tgz",
 			"integrity": "sha512-pMFOq2FRKpj0Eq0Jdc1H5gZOv5W0liMNVVAVgpHovA5Bmb8alESjFnS25Y7eapUx6pIbFmbnFeqkhLQGUefCqg==",
 			"license": "MIT"
 		},
@@ -3624,6 +3625,12 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/idb": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+			"integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+			"license": "ISC"
+		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4848,6 +4855,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/octagonal-wheels": {
+			"version": "0.1.47-preview.0",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/octagonal-wheels-0.1.47-preview.0.tgz",
+			"integrity": "sha512-R2uaqPmxU1vS/7AMHOJU11F5+Ankbi3Au4U3G6J03RnmEiVq98ONwBQgx8QgvVjsukRoG9E7mwLFSiP0cKRPKw==",
+			"license": "MIT",
+			"dependencies": {
+				"idb": "^8.0.3"
 			}
 		},
 		"node_modules/optionator": {
@@ -7284,20 +7300,20 @@
 			}
 		},
 		"@vrtmrz/obsidian-plugin-kit": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
 			"integrity": "sha512-nWPtnxO7wImPmANjSHlka1o62X/MQScCVvmegYtG0jW56fNPUvzLF5cd86RJUdUcTZsgXrk6s3d3N2SdXOR5Xw==",
 			"requires": {
 				"@vrtmrz/ui-interactions": "0.0.0"
 			}
 		},
 		"@vrtmrz/obsidian-test-session": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-obsidian-test-session-0.0.0.tgz",
 			"integrity": "sha512-XHWFORR8Q7vQsbKxrj8RBgpyC7DHFw5PSUXkBOKJoHnx9abgCkuQp4gYYa64RO7sOdRx/Xj799JOop+McQSqsg==",
 			"dev": true,
 			"requires": {}
 		},
 		"@vrtmrz/ui-interactions": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz",
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-ui-interactions-0.0.0.tgz",
 			"integrity": "sha512-pMFOq2FRKpj0Eq0Jdc1H5gZOv5W0liMNVVAVgpHovA5Bmb8alESjFnS25Y7eapUx6pIbFmbnFeqkhLQGUefCqg=="
 		},
 		"acorn": {
@@ -8653,6 +8669,11 @@
 				"function-bind": "^1.1.2"
 			}
 		},
+		"idb": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+			"integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="
+		},
 		"ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9373,6 +9394,13 @@
 			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
 			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"dev": true
+		},
+		"octagonal-wheels": {
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/octagonal-wheels-0.1.47-preview.0.tgz",
+			"integrity": "sha512-R2uaqPmxU1vS/7AMHOJU11F5+Ankbi3Au4U3G6J03RnmEiVq98ONwBQgx8QgvVjsukRoG9E7mwLFSiP0cKRPKw==",
+			"requires": {
+				"idb": "^8.0.3"
+			}
 		},
 		"optionator": {
 			"version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"lint": "eslint .",
 		"test": "vitest run",
 		"test:e2e:obsidian:add-target": "npm run build && tsx test/e2e-obsidian/add-target.mts",
+		"test:e2e:obsidian:restore-paths": "npm run build && tsx test/e2e-obsidian/restore-paths.mts",
 		"tsc-check": "tsc --noEmit --skipLibCheck"
 	},
 	"keywords": [],
@@ -22,7 +23,7 @@
 		"@emnapi/runtime": "1.11.2",
 		"@types/node": "^22.15.3",
 		"@typescript-eslint/parser": "^8.31.1",
-		"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
+		"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-obsidian-test-session-0.0.0.tgz",
 		"esbuild": "0.28.1",
 		"eslint": "^9.25.1",
 		"eslint-plugin-obsidianmd": "^0.3.0",
@@ -35,7 +36,8 @@
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
-		"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz"
+		"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
+		"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/vrtmrz-ui-interactions-0.0.0.tgz",
+		"octagonal-wheels": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.4/octagonal-wheels-0.1.47-preview.0.tgz"
 	}
 }

--- a/restore-path.ts
+++ b/restore-path.ts
@@ -1,0 +1,31 @@
+import { parseSafeRelativePath, resolvePathWithinRoot } from "octagonal-wheels/path";
+
+// eslint-disable-next-line obsidianmd/hardcoded-config-path -- Portable pseudo root stored in ScrewDriver notes, not the active Vault configuration path.
+export const PORTABLE_OBSIDIAN_CONFIG_DIR = ".obsidian";
+
+/** Inputs used to validate and resolve one path stored in a ScrewDriver block. */
+export interface ResolveRestorePathOptions {
+	/** Untrusted path parsed from the block header. */
+	readonly storedPath: string;
+	/** Trusted configuration directory reported by the active Vault. */
+	readonly configDir: string;
+	/** Whether the portable `.obsidian/` pseudo root should map to {@link configDir}. */
+	readonly adjustObsidianDir: boolean;
+}
+
+/**
+ * Validates a stored path and resolves it to the Vault adapter namespace.
+ *
+ * @throws `UnsafePathError` when the path is not a canonical portable relative path.
+ */
+export function resolveRestorePath(options: ResolveRestorePathOptions): string {
+	const safeStoredPath = parseSafeRelativePath(options.storedPath);
+	const portablePrefix = `${PORTABLE_OBSIDIAN_CONFIG_DIR}/`;
+	if (options.adjustObsidianDir && safeStoredPath.startsWith(portablePrefix)) {
+		return resolvePathWithinRoot(
+			options.configDir,
+			safeStoredPath.substring(portablePrefix.length),
+		);
+	}
+	return safeStoredPath;
+}

--- a/test/e2e-obsidian/README.md
+++ b/test/e2e-obsidian/README.md
@@ -2,13 +2,14 @@
 
 This local-only suite installs the built ScrewDriver plug-in into an isolated vault and profile through `@vrtmrz/obsidian-test-session`. It is not part of the default CI gate.
 
-The add-target scenario opens a real export note, selects the installed ScrewDriver directory through the Fancy Kit picker, confirms inclusion of plug-in data through the real Markdown dialog, and verifies the note properties written by ScrewDriver. It does not use scripted UI responses.
+The add-target scenario opens a real export note, selects the installed ScrewDriver directory through the Fancy Kit picker, confirms inclusion of plug-in data through the real Markdown dialog, and verifies the note properties written by ScrewDriver. The restore-path scenario writes one safe block inside the Vault and verifies that an unsafe sibling traversal is skipped. Neither scenario uses scripted UI responses.
 
 The suite is currently validated on Linux only. Set `OBSIDIAN_BINARY` and `OBSIDIAN_CLI` when the executables are outside the shared discovery paths.
 
 ```bash
 npm run check:e2e:obsidian
 npm run test:e2e:obsidian:add-target
+npm run test:e2e:obsidian:restore-paths
 ```
 
 Set `E2E_OBSIDIAN_KEEP_VAULT=true` to preserve the temporary vault and isolated application state for debugging.

--- a/test/e2e-obsidian/harness.mts
+++ b/test/e2e-obsidian/harness.mts
@@ -17,7 +17,13 @@ export interface ScrewDriverTestSession {
 	readonly vault: TemporaryVault;
 }
 
-export async function startScrewDriverTestSession(): Promise<ScrewDriverTestSession> {
+export interface StartScrewDriverTestSessionOptions {
+	readonly prepareVault?: (vault: TemporaryVault) => Promise<void>;
+}
+
+export async function startScrewDriverTestSession(
+	options: StartScrewDriverTestSessionOptions = {},
+): Promise<ScrewDriverTestSession> {
 	const cli = discoverObsidianCli();
 	if (!cli.binary) throw new Error(`Could not find obsidian-cli. Checked: ${cli.checked.join(", ")}`);
 	const vault = await createTemporaryVault({
@@ -27,6 +33,7 @@ export async function startScrewDriverTestSession(): Promise<ScrewDriverTestSess
 	});
 	try {
 		await writeFile(join(vault.path, EXPORT_NOTE_PATH), "---\ntargets: []\nfilters: []\n---\n", "utf8");
+		await options.prepareVault?.(vault);
 		const session = await startObsidianPluginSession({
 			binary: requireObsidianBinary(),
 			cliBinary: cli.binary,

--- a/test/e2e-obsidian/restore-paths.mts
+++ b/test/e2e-obsidian/restore-paths.mts
@@ -1,0 +1,122 @@
+import { access, readFile, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { withObsidianPage } from "@vrtmrz/obsidian-test-session";
+import {
+	EXPORT_NOTE_PATH,
+	SCREWDRIVER_PLUGIN_ID,
+	startScrewDriverTestSession,
+	stopScrewDriverTestSession,
+	type ScrewDriverTestSession,
+} from "./harness.mts";
+
+const RESTORE_COMMAND_ID = `${SCREWDRIVER_PLUGIN_ID}:screwdriver-restore`;
+const SAFE_PATH = "Restored/safe.txt";
+
+function escapeFilename(vaultPath: string): string {
+	return `screwdriver-escape-${basename(vaultPath)}.txt`;
+}
+
+function restoreNote(unsafePath: string): string {
+	return `---
+adjustObsidianDir: true
+skipNewFile: false
+skipOldFile: false
+---
+
+\`\`\`screwdriver:${unsafePath}:plain:0
+unsafe content
+\`\`\`
+
+\`\`\`screwdriver:${SAFE_PATH}:plain:0
+safe content
+\`\`\`
+`;
+}
+
+async function verifyRestorePathBoundary(testSession: ScrewDriverTestSession): Promise<void> {
+	const unsafePath = `../${escapeFilename(testSession.vault.path)}`;
+	const outsidePath = join(dirname(testSession.vault.path), escapeFilename(testSession.vault.path));
+	try {
+		await withObsidianPage(testSession.session.remoteDebuggingPort, async (page) => {
+			await page.evaluate(
+				async ({ commandId, notePath }) => {
+					const obsidianApp = (
+						globalThis as typeof globalThis & {
+							app?: {
+								commands?: { executeCommandById(commandId: string): boolean };
+								vault?: { getAbstractFileByPath(path: string): unknown };
+								workspace?: { getLeaf(): { openFile(file: unknown): Promise<void> } };
+							};
+						}
+					).app;
+					if (!obsidianApp?.commands || !obsidianApp.vault || !obsidianApp.workspace) {
+						throw new Error("Obsidian application APIs are unavailable");
+					}
+					const note = obsidianApp.vault.getAbstractFileByPath(notePath);
+					if (!note) throw new Error(`Restore note is unavailable: ${notePath}`);
+					await obsidianApp.workspace.getLeaf().openFile(note);
+					if (!obsidianApp.commands.executeCommandById(commandId)) {
+						throw new Error(`ScrewDriver command was not executed: ${commandId}`);
+					}
+				},
+				{ commandId: RESTORE_COMMAND_ID, notePath: EXPORT_NOTE_PATH },
+			);
+
+			await page.locator(".notice").filter({ hasText: "Skipped unsafe restore path" }).waitFor({
+				state: "visible",
+				timeout: 10_000,
+			});
+			await page.waitForFunction(
+				async (safePath) => {
+					const obsidianApp = (
+						globalThis as typeof globalThis & {
+							app?: {
+								vault?: {
+									adapter?: { exists(path: string): Promise<boolean> };
+								};
+							};
+						}
+					).app;
+					return await obsidianApp?.vault?.adapter?.exists(safePath) === true;
+				},
+				SAFE_PATH,
+				{ timeout: 10_000 },
+			);
+		});
+
+		const safeContent = await readFile(join(testSession.vault.path, SAFE_PATH), "utf8");
+		if (safeContent !== "safe content") {
+			throw new Error(`Unexpected restored content: ${JSON.stringify(safeContent)}`);
+		}
+		try {
+			await access(outsidePath);
+			throw new Error(`Unsafe restore escaped the Vault: ${outsidePath}`);
+		} catch (error) {
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+			throw error;
+		}
+	} finally {
+		await rm(outsidePath, { force: true });
+	}
+}
+
+async function main(): Promise<void> {
+	let testSession: ScrewDriverTestSession | undefined;
+	try {
+		testSession = await startScrewDriverTestSession({
+			prepareVault: async (vault) => {
+				const unsafePath = `../${escapeFilename(vault.path)}`;
+				await writeFile(join(vault.path, EXPORT_NOTE_PATH), restoreNote(unsafePath), "utf8");
+			},
+		});
+		await verifyRestorePathBoundary(testSession);
+		console.log("ScrewDriver safe restore and traversal rejection passed in real Obsidian");
+	} finally {
+		if (testSession) await stopScrewDriverTestSession(testSession);
+	}
+}
+
+main().catch((error: unknown) => {
+	console.error(error instanceof Error ? error.stack : error);
+	process.exit(1);
+});

--- a/tests/restore-path.test.ts
+++ b/tests/restore-path.test.ts
@@ -1,0 +1,69 @@
+import { UnsafePathError } from "octagonal-wheels/path";
+import { describe, expect, it } from "vitest";
+import {
+	PORTABLE_OBSIDIAN_CONFIG_DIR,
+	resolveRestorePath,
+} from "../restore-path";
+
+describe("restore path resolution", () => {
+	it("preserves a canonical Vault-relative path", () => {
+		expect(resolveRestorePath({
+			storedPath: "Attachments/image.png",
+			configDir: ".config",
+			adjustObsidianDir: true,
+		})).toBe("Attachments/image.png");
+	});
+
+	it("maps the portable Obsidian pseudo root below the active configuration directory", () => {
+		// eslint-disable-next-line obsidianmd/hardcoded-config-path -- Fixture exercises ScrewDriver's documented portable pseudo root.
+		const storedPath = ".obsidian/plugins/example/main.js";
+		expect(resolveRestorePath({
+			storedPath,
+			configDir: ".config",
+			adjustObsidianDir: true,
+		})).toBe(".config/plugins/example/main.js");
+	});
+
+	it("keeps the portable pseudo root literal when adjustment is disabled", () => {
+		const storedPath = `${PORTABLE_OBSIDIAN_CONFIG_DIR}/snippets/example.css`;
+		expect(resolveRestorePath({
+			storedPath,
+			configDir: ".config",
+			adjustObsidianDir: false,
+		})).toBe(storedPath);
+	});
+
+	it.each([
+		"",
+		"/tmp/escape.md",
+		"C:/Windows/system.ini",
+		"../escape.md",
+		"folder/../escape.md",
+		"folder\\escape.md",
+		"folder//file.md",
+		"folder/NUL.txt",
+		`${PORTABLE_OBSIDIAN_CONFIG_DIR}/../escape.md`,
+	])("rejects the unsafe or non-portable path %j", (storedPath) => {
+		expect(() => resolveRestorePath({
+			storedPath,
+			configDir: ".config",
+			adjustObsidianDir: true,
+		})).toThrow(UnsafePathError);
+	});
+
+	it("does not treat a similar prefix as the portable pseudo root", () => {
+		expect(resolveRestorePath({
+			storedPath: `${PORTABLE_OBSIDIAN_CONFIG_DIR}-backup/plugins/example/main.js`,
+			configDir: ".config",
+			adjustObsidianDir: true,
+		})).toBe(".obsidian-backup/plugins/example/main.js");
+	});
+
+	it("preserves the exact pseudo-root path to match the historical prefix contract", () => {
+		expect(resolveRestorePath({
+			storedPath: PORTABLE_OBSIDIAN_CONFIG_DIR,
+			configDir: ".config",
+			adjustObsidianDir: true,
+		})).toBe(PORTABLE_OBSIDIAN_CONFIG_DIR);
+	});
+});


### PR DESCRIPTION
## Summary

- consume `octagonal-wheels@0.1.47-preview.0` from Fancy Kit consumer preview `.5`
- validate every path parsed from a restore block before Vault adapter access or directory creation
- preserve ScrewDriver's portable `.obsidian/` pseudo-root contract while resolving it below the active `vault.configDir`
- add App-free path-policy tests and a local-only real Obsidian traversal scenario

## Why

Restore block headers are note-controlled input. ScrewDriver previously passed the parsed filename directly to `adapter.stat`, `ensureDirectory`, `write`, or `writeBinary`. Absolute paths, parent traversal, backslash variants, empty components, and platform-invalid names were not rejected explicitly.

The new boundary accepts canonical portable Vault-relative paths without normalising them. When `adjustObsidianDir` is enabled, only the validated suffix below the documented `.obsidian/` pseudo root is joined to the trusted active configuration directory. Unsafe blocks are reported and skipped, allowing later safe blocks to continue.

## User impact

Ordinary ScrewDriver notes and portable `.obsidian/...` exports keep their existing meaning. Historical Linux-only notes containing names that are invalid or reserved on common desktop platforms are now skipped rather than restored. The README documents the accepted path contract.

## Dependency note

Fancy Kit is not published to npm. All Fancy Kit dependencies are pinned to immutable assets from `consumer-preview-2026-07-10.5`; scoped packages report version `0.1.0`, and `octagonal-wheels/path` is supplied by `octagonal-wheels@0.1.47-preview.0`.

## Validation

- clean `npm ci`; zero vulnerabilities
- `npm run check` (lint, 19 Vitest tests, TypeScript)
- `npm run check:e2e:obsidian`
- `npm run build`
- `npm ls` reports the three scoped Fancy Kit packages at `0.1.0` and OW at `0.1.47-preview.0`
- real Obsidian add-target picker and confirmation scenario passed on Linux
- real Obsidian restore scenario skipped a sibling traversal, restored the following safe block, and verified that no file was created outside the isolated Vault

Unit tests cover canonical paths, unsafe variants, portable `.obsidian/` mapping, and non-default `configDir` mapping. The real Obsidian scenario already covers unsafe rejection followed by safe continuation.

## Reduced actual-device gate

The combined `0.0.12-fancy.1` pre-release passed the reduced gates before these changes reached `main`.

- [x] Confirm the combined release was installed and the reduced UI gate on #6 passed
- [x] On desktop, restore the fixture below and confirm an unsafe-path Notice appears, no file is created outside the Vault, and `Screwdriver-preview/safe.txt` is restored with exactly `safe content`
- [x] Record the restore result and test environment here

A separate ordinary-restore run is unnecessary because the safe block after the rejected block proves that restoration continues. Testing `.obsidian/...` with a non-default active `configDir` is optional when such a Vault is readily available; otherwise the focused unit test is sufficient.

Paste the following into a new Markdown note:

````markdown
---
targets: []
urls: []
ignores: []
filters: []
adjustObsidianDir: true
skipNewFile: false
skipOldFile: false
---

```screwdriver:../screwdriver-preview-escape.txt:plain:0
unsafe content
```

```screwdriver:Screwdriver-preview/safe.txt:plain:0
safe content
```
````

## Review shape

PR #6 is merged. This PR now targets `main`; its diff is limited to restore-path validation and the required Fancy Kit and OW preview dependencies.
