### PR TITLE
Use stable Fancy Kit packages

### DIFF
--- a/docs/devs.md
+++ b/docs/devs.md
@@ -30,9 +30,9 @@ const harness = createUiTestHarness([
 
 Scripted responses are instance-scoped. Call `assertDone()` so an expected interaction that did not occur fails the test. Closing the plug-in-data confirmation follows the safe exclude path.
 
-## Fancy Kit preview
+## Fancy Kit dependencies
 
-Until Fancy Kit is published to npm, its packages are pinned to immutable tarballs from one GitHub prerelease. Update all Fancy Kit package URLs used by the plug-in together when a migration needs a newer preview. The restore path boundary currently consumes the OW prerelease from the same preview tag.
+The Fancy Kit packages and `octagonal-wheels` are pinned to exact npm versions so the tested dependency set remains reproducible. Review and update the four versions together when adopting a newer contract. The restore path boundary currently consumes the path contract introduced in `octagonal-wheels@0.1.48`.
 
 The App-free tests verify workflow policy and the UI transcript. They do not replace real Obsidian coverage for modal rendering, keyboard handling, focus, or theme behaviour.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
 			"version": "0.0.12",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-				"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
-				"octagonal-wheels": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/octagonal-wheels-0.1.47-preview.0.tgz"
+				"@vrtmrz/obsidian-plugin-kit": "0.1.0",
+				"@vrtmrz/ui-interactions": "0.1.0",
+				"octagonal-wheels": "0.1.48"
 			},
 			"devDependencies": {
 				"@emnapi/core": "1.11.2",
 				"@emnapi/runtime": "1.11.2",
 				"@types/node": "^22.15.3",
 				"@typescript-eslint/parser": "^8.31.1",
-				"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
+				"@vrtmrz/obsidian-test-session": "0.1.0",
 				"esbuild": "0.28.1",
 				"eslint": "^9.25.1",
 				"eslint-plugin-obsidianmd": "^0.3.0",
@@ -1618,8 +1618,8 @@
 		},
 		"node_modules/@vrtmrz/obsidian-plugin-kit": {
 			"version": "0.1.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-			"integrity": "sha512-FttoY0IEt8pbsI3cfAt+qzzg9Ruavka9v7vmBVT/hO1qSSt5ruu6aGS5y21km9qV4PcCmCZOTcDtLTD4ZS+osA==",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
+			"integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
 			"license": "MIT",
 			"dependencies": {
 				"@vrtmrz/ui-interactions": "0.1.0"
@@ -1630,21 +1630,22 @@
 		},
 		"node_modules/@vrtmrz/obsidian-test-session": {
 			"version": "0.1.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
-			"integrity": "sha512-IUM31s7jjhj7S2X6qM7QIvgJX/XzK35878phq/wuLI849BdwfXIliUcnAdqcDN9ajGbLuMkFHy1h2Q2LB0A93A==",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-test-session/-/obsidian-test-session-0.1.0.tgz",
+			"integrity": "sha512-asBOIRTc3xK5GF5ds5mkxN6vsO4RE8o7puvVjoJiGYSlxoFa9jzr8FwAO13CyoOriHF05pOZfTB+eQmL1aNb/A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
 			},
 			"peerDependencies": {
+				"@types/node": ">=20",
 				"playwright": ">=1.50.0"
 			}
 		},
 		"node_modules/@vrtmrz/ui-interactions": {
 			"version": "0.1.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
-			"integrity": "sha512-m+15ffZrjrmM7juusfVsp3smeQo1LSPNzIUIRlpnYY4n3PQn5RmM8yR/317LIVGjC41pqhthfRqEJUCNod4c3g==",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/ui-interactions/-/ui-interactions-0.1.0.tgz",
+			"integrity": "sha512-2K+DgrEdH+MaNXQOZySSfGkYTc8xMlOuaHXX/tZOC/CC8AgPF9+SjjmgpO8hZeZUZiYC2vevdGvS0yxOh1Jnjw==",
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
@@ -4858,9 +4859,9 @@
 			}
 		},
 		"node_modules/octagonal-wheels": {
-			"version": "0.1.47-preview.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/octagonal-wheels-0.1.47-preview.0.tgz",
-			"integrity": "sha512-R2uaqPmxU1vS/7AMHOJU11F5+Ankbi3Au4U3G6J03RnmEiVq98ONwBQgx8QgvVjsukRoG9E7mwLFSiP0cKRPKw==",
+			"version": "0.1.48",
+			"resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.48.tgz",
+			"integrity": "sha512-uCUEGK4UUkmumPI/fE45r877+mpANvSPe9E4O2LT95vN6Nk9PHaqQDq8NWCiYTWTlGptlhsNBstH/WxSh0ocFg==",
 			"license": "MIT",
 			"dependencies": {
 				"idb": "^8.0.3"
@@ -7300,21 +7301,24 @@
 			}
 		},
 		"@vrtmrz/obsidian-plugin-kit": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-			"integrity": "sha512-FttoY0IEt8pbsI3cfAt+qzzg9Ruavka9v7vmBVT/hO1qSSt5ruu6aGS5y21km9qV4PcCmCZOTcDtLTD4ZS+osA==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
+			"integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
 			"requires": {
 				"@vrtmrz/ui-interactions": "0.1.0"
 			}
 		},
 		"@vrtmrz/obsidian-test-session": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
-			"integrity": "sha512-IUM31s7jjhj7S2X6qM7QIvgJX/XzK35878phq/wuLI849BdwfXIliUcnAdqcDN9ajGbLuMkFHy1h2Q2LB0A93A==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-test-session/-/obsidian-test-session-0.1.0.tgz",
+			"integrity": "sha512-asBOIRTc3xK5GF5ds5mkxN6vsO4RE8o7puvVjoJiGYSlxoFa9jzr8FwAO13CyoOriHF05pOZfTB+eQmL1aNb/A==",
 			"dev": true,
 			"requires": {}
 		},
 		"@vrtmrz/ui-interactions": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
-			"integrity": "sha512-m+15ffZrjrmM7juusfVsp3smeQo1LSPNzIUIRlpnYY4n3PQn5RmM8yR/317LIVGjC41pqhthfRqEJUCNod4c3g=="
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/ui-interactions/-/ui-interactions-0.1.0.tgz",
+			"integrity": "sha512-2K+DgrEdH+MaNXQOZySSfGkYTc8xMlOuaHXX/tZOC/CC8AgPF9+SjjmgpO8hZeZUZiYC2vevdGvS0yxOh1Jnjw=="
 		},
 		"acorn": {
 			"version": "8.17.0",
@@ -9396,8 +9400,9 @@
 			"dev": true
 		},
 		"octagonal-wheels": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/octagonal-wheels-0.1.47-preview.0.tgz",
-			"integrity": "sha512-R2uaqPmxU1vS/7AMHOJU11F5+Ankbi3Au4U3G6J03RnmEiVq98ONwBQgx8QgvVjsukRoG9E7mwLFSiP0cKRPKw==",
+			"version": "0.1.48",
+			"resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.48.tgz",
+			"integrity": "sha512-uCUEGK4UUkmumPI/fE45r877+mpANvSPe9E4O2LT95vN6Nk9PHaqQDq8NWCiYTWTlGptlhsNBstH/WxSh0ocFg==",
 			"requires": {
 				"idb": "^8.0.3"
 			}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"@emnapi/runtime": "1.11.2",
 		"@types/node": "^22.15.3",
 		"@typescript-eslint/parser": "^8.31.1",
-		"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
+		"@vrtmrz/obsidian-test-session": "0.1.0",
 		"esbuild": "0.28.1",
 		"eslint": "^9.25.1",
 		"eslint-plugin-obsidianmd": "^0.3.0",
@@ -36,8 +36,8 @@
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-		"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
-		"octagonal-wheels": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/octagonal-wheels-0.1.47-preview.0.tgz"
+		"@vrtmrz/obsidian-plugin-kit": "0.1.0",
+		"@vrtmrz/ui-interactions": "0.1.0",
+		"octagonal-wheels": "0.1.48"
 	}
 }


### PR DESCRIPTION
## Summary

- replace the Fancy Kit preview tarballs with exact npm registry versions
- move `octagonal-wheels` from the reviewed preview to `0.1.48`
- update the developer documentation to describe the reproducible stable dependency set

## Why

The four packages have now passed the trusted staged publication flow. Consuming their exact registry versions verifies that the published packages preserve the contracts already reviewed through the preview release, without relying on GitHub release assets.

There is no intended user-facing behaviour change. The restore-path boundary continues to accept safe Vault-relative paths and reject traversal.

## Validation

- [x] `npm ci`
- [x] `npm run check` (19 tests)
- [x] `npm run build`
- [x] `npm run check:e2e:obsidian`
- [x] real Obsidian restore-path scenario on Linux
- [x] safe content restored inside the Vault
- [x] sibling traversal rejected without creating an outside file

The real-Obsidian run used the local-only isolated-vault harness and Obsidian 1.12.7.
