### PR TITLE
Narrow Vault read capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check
+        run: npm run check
+
+      - name: Build
+        run: npm run build
+
+      - name: Type-check local-only real-Obsidian E2E scripts
+        run: npm run check:e2e:obsidian

--- a/docs/devs.md
+++ b/docs/devs.md
@@ -46,6 +46,14 @@ npm run test:e2e:obsidian:restore-paths
 
 Real-Obsidian E2E is currently validated on Linux only and is not part of the default CI gate.
 
+## Vault read boundary
+
+`vault-read.ts` defines the narrow, ScrewDriver-owned capabilities used by target discovery and dump capture: direct-child listing, binary reads, and metadata reads. The production composition supplies `app.vault.adapter`, which is already bound to the active Vault root. All paths passed to these helpers remain Vault-relative; the helpers do not select or discover a root.
+
+The App-free tests use structural fakes to verify recursive listing results, ignored-subtree behaviour, exact binary data, missing metadata, and deterministic adapter operation counts. These types are an internal consumer pilot, not a neutral Fancy Kit storage API.
+
+Restore writes and directory creation remain outside this boundary. Their overwrite, missing-path, error, and folder-creation semantics need comparison with another consumer before a shared contract is appropriate.
+
 ## Restore path boundary
 
 Paths parsed from fenced block headers are untrusted input. `restore-path.ts` uses `octagonal-wheels/path` to accept only canonical portable relative paths before any Vault adapter `stat`, directory creation, or write operation.

--- a/docs/devs.md
+++ b/docs/devs.md
@@ -10,6 +10,8 @@ npm run check
 npm run build
 ```
 
+Pull requests and pushes to `main` run the same clean installation, repository check, production build, and local-only E2E script typecheck on GitHub Actions. CI does not download or launch Obsidian. Real Obsidian remains an explicit local validation because repeatedly acquiring and launching the desktop application is inappropriate for the default remote gate without a separate review of distribution traffic, caching, and runner support.
+
 ## UI boundary
 
 The plug-in owns one `UiInteractions` capability for its lifetime:

--- a/main.ts
+++ b/main.ts
@@ -3,44 +3,11 @@ import { UnsafePathError } from "octagonal-wheels/path";
 import { App, Editor, MarkdownView, Notice, parseYaml, Plugin, requestUrl, arrayBufferToBase64, base64ToArrayBuffer, MarkdownRenderer, TFile, type MarkdownFileInfo, MarkdownRenderChild } from "obsidian";
 import { PORTABLE_OBSIDIAN_CONFIG_DIR, resolveRestorePath } from "./restore-path";
 import { chooseTargetDirectory, shouldIncludePluginData } from "./ui-workflow";
-// Util functions
-async function getFiles(
-	app: App,
-	path: string,
-	ignoreList: string[],
-	filter: RegExp[]
-) {
-	const w = await app.vault.adapter.list(path);
-	let files = [
-		...w.files
-			.filter((e) => !ignoreList.some((ee) => e.endsWith(ee)))
-			.filter((e) => !filter || filter.some((ee) => e.match(ee))),
-	];
-	L1: for (const v of w.folders) {
-		for (const ignore of ignoreList) {
-			if (v.endsWith(ignore)) {
-				continue L1;
-			}
-		}
-		// files = files.concat([v]);
-		files = files.concat(await getFiles(app, v, ignoreList, filter));
-	}
-	return files;
-}
-async function getDirectories(app: App, path: string, ignoreList: string[]) {
-	const w = await app.vault.adapter.list(path);
-	let dirs: string[] = [];
-	L1: for (const v of w.folders) {
-		for (const ignore of ignoreList) {
-			if (v.endsWith(ignore)) {
-				continue L1;
-			}
-		}
-		dirs = dirs.concat([v]);
-		dirs = dirs.concat(await getDirectories(app, v, ignoreList));
-	}
-	return dirs;
-}
+import {
+	listVaultDirectoriesRecursively,
+	listVaultFilesRecursively,
+	readVaultFileForDump,
+} from "./vault-read";
 
 function isPlainText(filename: string): boolean {
 	if (filename.endsWith(".md")) return true;
@@ -88,8 +55,8 @@ export default class ScrewDriverPlugin extends Plugin {
 			id: "screwdriver-add-target-dir",
 			name: "Add folder to this export note",
 			editorCallback: async (_editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
-				const list = await getDirectories(
-					this.app,
+				const list = await listVaultDirectoriesRecursively(
+					this.app.vault.adapter,
 					this.app.vault.configDir,
 					["node_modules", ".git"]
 				);
@@ -106,7 +73,7 @@ export default class ScrewDriverPlugin extends Plugin {
 					} else if (selected.indexOf("themes") !== -1) {
 						filters = ["manifest\\.json$", "theme\\.css$"];
 					} else if (selected.indexOf("snippets") !== -1) {
-						filters = (await getFiles(this.app, selected, [], [/\.css$/])).map(e => e.substring(selected.length).replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$");
+						filters = (await listVaultFilesRecursively(this.app.vault.adapter, selected, [], [/\.css$/])).map(e => e.substring(selected.length).replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$");
 					}
 					if (!(view.file instanceof TFile)) {
 						new Notice("Current file is not a valid file.");
@@ -224,8 +191,8 @@ export default class ScrewDriverPlugin extends Plugin {
 				}
 
 				for (const target of targets) {
-					const files = await getFiles(
-						this.app,
+					const files = await listVaultFilesRecursively(
+						this.app.vault.adapter,
 						target,
 						ignores,
 						filters
@@ -233,12 +200,12 @@ export default class ScrewDriverPlugin extends Plugin {
 					for (const file of files) {
 						let fileDat = "";
 						let bin = false;
-						const dt = await this.app.vault.adapter.readBinary(file);
-						const stat = await this.app.vault.adapter.stat(file);
-						if (stat == null) {
+						const captured = await readVaultFileForDump(this.app.vault.adapter, file);
+						if (captured === null) {
 							new Notice(`File can not be accessed: ${file}`);
 							continue;
 						}
+						const { data: dt, stat } = captured;
 						try {
 							const text = new TextDecoder("utf-8", { fatal: true }).decode(dt);
 							fileDat = text;

--- a/tests/vault-read.test.ts
+++ b/tests/vault-read.test.ts
@@ -1,0 +1,148 @@
+import type { Stat } from "obsidian";
+import { describe, expect, it } from "vitest";
+import {
+	listVaultDirectoriesRecursively,
+	listVaultFilesRecursively,
+	readVaultFileForDump,
+	type VaultDirectoryListing,
+	type VaultDirectoryReadAccess,
+	type VaultDumpFileReadAccess,
+} from "../vault-read";
+
+function createDirectoryAccess(listings: Readonly<Record<string, VaultDirectoryListing>>) {
+	const transcript: string[] = [];
+	const vault: VaultDirectoryReadAccess = {
+		list(path) {
+			transcript.push(path);
+			const listing = listings[path];
+			if (listing === undefined) throw new Error(`Unexpected directory read: ${path}`);
+			return Promise.resolve(listing);
+		},
+	};
+	return { transcript, vault };
+}
+
+describe("Vault read capabilities", () => {
+	it("lists filtered files once per visited directory without scanning ignored folders", async () => {
+		const access = createDirectoryAccess({
+			".config": {
+				files: [".config/app.json", ".config/workspace"],
+				folders: [".config/plugins", ".config/node_modules"],
+			},
+			".config/plugins": {
+				files: [".config/plugins/manifest.json", ".config/plugins/main.js"],
+				folders: [".config/plugins/example"],
+			},
+			".config/plugins/example": {
+				files: [".config/plugins/example/data.json", ".config/plugins/example/styles.css"],
+				folders: [],
+			},
+		});
+
+		await expect(listVaultFilesRecursively(
+			access.vault,
+			".config",
+			["node_modules"],
+			[/\.json$/],
+		)).resolves.toEqual([
+			".config/app.json",
+			".config/plugins/manifest.json",
+			".config/plugins/example/data.json",
+		]);
+		expect(access.transcript).toEqual([
+			".config",
+			".config/plugins",
+			".config/plugins/example",
+		]);
+	});
+
+	it("lists directories without entering ignored subtrees", async () => {
+		const access = createDirectoryAccess({
+			".config": {
+				files: [],
+				folders: [".config/plugins", ".config/.git"],
+			},
+			".config/plugins": {
+				files: [],
+				folders: [".config/plugins/example"],
+			},
+			".config/plugins/example": { files: [], folders: [] },
+		});
+
+		await expect(listVaultDirectoriesRecursively(
+			access.vault,
+			".config",
+			[".git"],
+		)).resolves.toEqual([
+			".config/plugins",
+			".config/plugins/example",
+		]);
+		expect(access.transcript).toEqual([
+			".config",
+			".config/plugins",
+			".config/plugins/example",
+		]);
+	});
+
+	it("lists every non-ignored file when no filter is configured", async () => {
+		const access = createDirectoryAccess({
+			Notes: {
+				files: ["Notes/one.md", "Notes/two.bin", "Notes/generated.tmp"],
+				folders: [],
+			},
+		});
+
+		await expect(listVaultFilesRecursively(
+			access.vault,
+			"Notes",
+			[".tmp"],
+			null,
+		)).resolves.toEqual([
+			"Notes/one.md",
+			"Notes/two.bin",
+		]);
+		expect(access.transcript).toEqual(["Notes"]);
+	});
+
+	it("captures exact binary data and metadata through a narrow capability", async () => {
+		const transcript: string[] = [];
+		const data = new Uint8Array([1, 2, 3]).buffer;
+		const stat: Stat = { ctime: 10, mtime: 20, size: 3, type: "file" };
+		const vault: VaultDumpFileReadAccess = {
+			readBinary(path) {
+				transcript.push(`readBinary:${path}`);
+				return Promise.resolve(data);
+			},
+			stat(path) {
+				transcript.push(`stat:${path}`);
+				return Promise.resolve(stat);
+			},
+		};
+
+		await expect(readVaultFileForDump(vault, "Assets/image.bin")).resolves.toEqual({ data, stat });
+		expect(transcript).toEqual([
+			"readBinary:Assets/image.bin",
+			"stat:Assets/image.bin",
+		]);
+	});
+
+	it("returns null when metadata disappears after the binary read", async () => {
+		const transcript: string[] = [];
+		const vault: VaultDumpFileReadAccess = {
+			readBinary(path) {
+				transcript.push(`readBinary:${path}`);
+				return Promise.resolve(new ArrayBuffer(0));
+			},
+			stat(path) {
+				transcript.push(`stat:${path}`);
+				return Promise.resolve(null);
+			},
+		};
+
+		await expect(readVaultFileForDump(vault, "removed.bin")).resolves.toBeNull();
+		expect(transcript).toEqual([
+			"readBinary:removed.bin",
+			"stat:removed.bin",
+		]);
+	});
+});

--- a/vault-read.ts
+++ b/vault-read.ts
@@ -1,0 +1,75 @@
+import type { Stat } from "obsidian";
+
+/** Direct children returned by a root-bound Vault directory adapter. */
+export interface VaultDirectoryListing {
+	readonly files: readonly string[];
+	readonly folders: readonly string[];
+}
+
+/** Directory-read capability used by ScrewDriver's target discovery and dump workflow. */
+export interface VaultDirectoryReadAccess {
+	list(path: string): Promise<VaultDirectoryListing>;
+}
+
+/** Binary-read capability used while capturing a file for a ScrewDriver dump. */
+export interface VaultBinaryReadAccess {
+	readBinary(path: string): Promise<ArrayBuffer>;
+}
+
+/** Metadata capability used while capturing a file for a ScrewDriver dump. */
+export interface VaultMetadataReadAccess {
+	stat(path: string): Promise<Stat | null>;
+}
+
+/** Minimal root-bound Vault capability required to capture one dump file. */
+export interface VaultDumpFileReadAccess extends VaultBinaryReadAccess, VaultMetadataReadAccess {}
+
+export interface VaultDumpFile {
+	readonly data: ArrayBuffer;
+	readonly stat: Stat;
+}
+
+/** Lists matching files recursively without entering ignored folders. */
+export async function listVaultFilesRecursively(
+	vault: VaultDirectoryReadAccess,
+	path: string,
+	ignoreList: readonly string[],
+	filter: readonly RegExp[] | null,
+): Promise<string[]> {
+	const listing = await vault.list(path);
+	let files = listing.files
+		.filter((file) => !ignoreList.some((ignored) => file.endsWith(ignored)))
+		.filter((file) => filter === null || filter.some((pattern) => file.match(pattern)));
+
+	for (const folder of listing.folders) {
+		if (ignoreList.some((ignored) => folder.endsWith(ignored))) continue;
+		files = files.concat(await listVaultFilesRecursively(vault, folder, ignoreList, filter));
+	}
+	return files;
+}
+
+/** Lists folders recursively without entering ignored folders. */
+export async function listVaultDirectoriesRecursively(
+	vault: VaultDirectoryReadAccess,
+	path: string,
+	ignoreList: readonly string[],
+): Promise<string[]> {
+	const listing = await vault.list(path);
+	let directories: string[] = [];
+	for (const folder of listing.folders) {
+		if (ignoreList.some((ignored) => folder.endsWith(ignored))) continue;
+		directories = directories.concat(folder);
+		directories = directories.concat(await listVaultDirectoriesRecursively(vault, folder, ignoreList));
+	}
+	return directories;
+}
+
+/** Reads one dump file while preserving ScrewDriver's existing read-then-stat order. */
+export async function readVaultFileForDump(
+	vault: VaultDumpFileReadAccess,
+	path: string,
+): Promise<VaultDumpFile | null> {
+	const data = await vault.readBinary(path);
+	const stat = await vault.stat(path);
+	return stat === null ? null : { data, stat };
+}


### PR DESCRIPTION
## Summary

- define ScrewDriver-owned, root-bound Vault capabilities for direct-child listing, binary reads, and metadata reads;
- move recursive target discovery and dump-file capture out of the plug-in class;
- pass the existing `app.vault.adapter` directly, without a wrapper or runtime platform selector;
- add App-free tests for filters, ignored subtrees, exact binary data, missing metadata, and deterministic adapter operation counts;
- document why restore writes, directory creation, and deletion remain outside this pilot; and
- add pull-request and `main` CI for clean installation, checks, production build, and local-only E2E script typechecking.

## Motivation

The previous helpers accepted the complete Obsidian `App` and lived inside `main.ts`, which made recursive-scan behaviour and dump reads difficult to test without reproducing the complete application graph.

The narrower structural capabilities let tests supply only `list`, or `readBinary` and `stat`. Their signatures can also be compared with the focused LiveSync storage capabilities before considering any neutral Fancy Kit package. These are internal consumer types, not a proposed public storage API.

## Impact

No runtime behaviour change is intended. The production composition still uses the Vault-root-bound `app.vault.adapter`, recursive traversal preserves the existing ordering and ignore/filter policy, and dump capture preserves the existing read-then-stat order.

Restore writes and folder creation are unchanged. Their overwrite, missing-path, exception, and destructive-operation semantics remain separate until another consumer demonstrates a compatible contract.

CI does not download or launch Obsidian. It only type-checks the local real-Obsidian E2E scripts; desktop application validation remains an explicit local step to avoid inappropriate repeated requests to the Obsidian distribution source.

## Validation

- GitHub Actions `verify`: passed on the pull-request head;
- `npm run check` — 24 tests passed, including five focused Vault read tests;
- `npm run build`;
- `npm run check:e2e:obsidian`;
- `actionlint` and YAML parsing for the CI workflow;
- real Obsidian 1.12.7 add-target scenario: plug-in enable/reload, recursive directory discovery, picker selection, confirmation, and frontmatter update passed; and
- real Obsidian 1.12.7 restore scenario: safe restore and traversal rejection passed.
