### PR TITLE
Isolate Vault restore operations

### DIFF
--- a/docs/devs.md
+++ b/docs/devs.md
@@ -54,7 +54,15 @@ Real-Obsidian E2E is currently validated on Linux only and is not part of the de
 
 The App-free tests use structural fakes to verify recursive listing results, ignored-subtree behaviour, exact binary data, missing metadata, and deterministic adapter operation counts. These types are an internal consumer pilot, not a neutral Fancy Kit storage API.
 
-Restore writes and directory creation remain outside this boundary. Their overwrite, missing-path, error, and folder-creation semantics need comparison with another consumer before a shared contract is appropriate.
+Restore writes and directory creation use the separate, operation-specific boundary described below. Neither boundary is a neutral Fancy Kit storage API.
+
+## Vault restore boundary
+
+`vault-restore.ts` separates ScrewDriver's overwrite policy from the concrete Obsidian Vault operations. `restoreVaultFile` accepts only metadata, parent-directory preparation, text upsert, and binary upsert capabilities. The production adapter is created once for each restore command and remains bound to the active Vault root.
+
+The adapter checks and creates each successful parent folder once during that command. It confirms folder state structurally instead of matching an English Obsidian error message, and a folder-creation failure stops the affected write. App-free tests preserve the existing modification-time comparisons, including the historical overwrite behaviour for an invalid stored timestamp, and verify operation order, exact binary data, and failure propagation.
+
+These capabilities remain ScrewDriver-owned. In particular, writes are create-or-overwrite operations, the modification-time check is best-effort rather than atomic, and OW path validation provides lexical safety rather than symbolic-link containment. Compare these semantics with another concrete consumer before extracting a neutral storage contract.
 
 ## Restore path boundary
 

--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,9 @@
 import { createObsidianUi, type UiInteractions } from "@vrtmrz/obsidian-plugin-kit/ui";
 import { UnsafePathError } from "octagonal-wheels/path";
-import { App, Editor, MarkdownView, Notice, parseYaml, Plugin, requestUrl, arrayBufferToBase64, base64ToArrayBuffer, MarkdownRenderer, TFile, type MarkdownFileInfo, MarkdownRenderChild } from "obsidian";
+import { Editor, MarkdownView, Notice, parseYaml, Plugin, requestUrl, arrayBufferToBase64, base64ToArrayBuffer, MarkdownRenderer, TFile, type MarkdownFileInfo, MarkdownRenderChild } from "obsidian";
 import { PORTABLE_OBSIDIAN_CONFIG_DIR, resolveRestorePath } from "./restore-path";
 import { chooseTargetDirectory, shouldIncludePluginData } from "./ui-workflow";
+import { createObsidianVaultRestoreAccess, restoreVaultFile } from "./vault-restore";
 import {
 	listVaultDirectoriesRecursively,
 	listVaultFilesRecursively,
@@ -23,26 +24,6 @@ function isPlainText(filename: string): boolean {
 	if (filename.endsWith(".canvas")) return true;
 
 	return false;
-}
-
-async function ensureDirectory(app: App, fullpath: string) {
-	const pathElements = fullpath.split("/");
-	pathElements.pop();
-	let c = "";
-	for (const v of pathElements) {
-		c += v;
-		try {
-			await app.vault.createFolder(c);
-		} catch (ex) {
-			// basically skip exceptions.
-			if (ex instanceof Error && ex.message == "Folder already exists.") {
-				// especially this message is.
-			} else {
-				new Notice("Folder Create Error");
-			}
-		}
-		c += "/";
-	}
 }
 
 export default class ScrewDriverPlugin extends Plugin {
@@ -255,6 +236,7 @@ export default class ScrewDriverPlugin extends Plugin {
 			id: "screwdriver-restore",
 			name: "Restore files from this note",
 			editorCallback: async (_editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
+				const restoreAccess = createObsidianVaultRestoreAccess(this.app.vault);
 				if (!("data" in view) || typeof view.data !== "string") {
 					new Notice("Current file is not a valid file.");
 					return;
@@ -288,44 +270,32 @@ export default class ScrewDriverPlugin extends Plugin {
 								continue;
 							}
 
-							let saveData = data;
 							try {
 								const mtime = parseInt(mtimeStr);
-								const stat = await this.app.vault.adapter.stat(filename);
-								if (stat !== null) {
-									if (skipOldFile && mtime < stat.mtime) {
-										new Notice(`File:${filename} is already up to date.`);
-										continue;
-									}
-									if (skipNewFile && mtime >= stat.mtime) {
-										new Notice(`File:${filename} already exists.`);
-										continue;
-									}
+								const result = await restoreVaultFile(restoreAccess, {
+									path: filename,
+									createPayload() {
+										let saveData = data;
+										if ((isPlainText(filename) && dataType != "bin") || dataType == "plain") {
+											saveData = saveData.replace(/\\`/g, "`");
+											saveData = saveData.replace(/\\\\/g, "\\");
+											saveData = saveData.substring(0, saveData.lastIndexOf("\n"));
+											return { kind: "text", data: saveData };
+										}
+										saveData = saveData.substring(0, saveData.lastIndexOf("\n"));
+										return { kind: "binary", data: base64ToArrayBuffer(saveData) };
+									},
+									storedMtime: mtime,
+									skipOldFile,
+									skipNewFile,
+								});
+								if (result === "skipped-up-to-date") {
+									new Notice(`File:${filename} is already up to date.`);
+									continue;
 								}
-								if ((isPlainText(filename) && dataType != "bin") || dataType == "plain") {
-									saveData = saveData.replace(/\\`/g, "`");
-									saveData = saveData.replace(/\\\\/g, "\\");
-									saveData = saveData.substring(
-										0,
-										saveData.lastIndexOf("\n")
-									);
-									await ensureDirectory(this.app, filename);
-									await this.app.vault.adapter.write(
-										filename,
-										saveData
-									);
-								} else {
-									saveData = saveData.substring(
-										0,
-										saveData.lastIndexOf("\n")
-									);
-									const saveDataArrayBuffer =
-										base64ToArrayBuffer(saveData);
-									await ensureDirectory(this.app, filename);
-									await this.app.vault.adapter.writeBinary(
-										filename,
-										saveDataArrayBuffer
-									);
+								if (result === "skipped-existing") {
+									new Notice(`File:${filename} already exists.`);
+									continue;
 								}
 								new Notice(
 									`File:${filename} has been wrote to your device.`

--- a/test/e2e-obsidian/README.md
+++ b/test/e2e-obsidian/README.md
@@ -2,7 +2,7 @@
 
 This local-only suite installs the built ScrewDriver plug-in into an isolated vault and profile through `@vrtmrz/obsidian-test-session`. It is not part of the default CI gate.
 
-The add-target scenario opens a real export note, selects the installed ScrewDriver directory through the Fancy Kit picker, confirms inclusion of plug-in data through the real Markdown dialog, and verifies the note properties written by ScrewDriver. The restore-path scenario writes one safe block inside the Vault and verifies that an unsafe sibling traversal is skipped. Neither scenario uses scripted UI responses.
+The add-target scenario opens a real export note, selects the installed ScrewDriver directory through the Fancy Kit picker, confirms inclusion of plug-in data through the real Markdown dialog, and verifies the note properties written by ScrewDriver. The restore-path scenario restores nested sibling text files and exact binary data, preserves an existing newer file, and verifies that an unsafe sibling traversal is skipped. Neither scenario uses scripted UI responses.
 
 The suite is currently validated on Linux only. Set `OBSIDIAN_BINARY` and `OBSIDIAN_CLI` when the executables are outside the shared discovery paths.
 

--- a/test/e2e-obsidian/restore-paths.mts
+++ b/test/e2e-obsidian/restore-paths.mts
@@ -1,4 +1,4 @@
-import { access, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { withObsidianPage } from "@vrtmrz/obsidian-test-session";
 import {
@@ -10,7 +10,11 @@ import {
 } from "./harness.mts";
 
 const RESTORE_COMMAND_ID = `${SCREWDRIVER_PLUGIN_ID}:screwdriver-restore`;
-const SAFE_PATH = "Restored/safe.txt";
+const SAFE_PATH = "Restored/nested/safe.txt";
+const SIBLING_PATH = "Restored/nested/sibling.txt";
+const BINARY_PATH = "Restored/nested/bytes.bin";
+const SKIPPED_PATH = "Restored/existing.txt";
+const BINARY_CONTENT = new Uint8Array([0, 1, 2, 255]);
 
 function escapeFilename(vaultPath: string): string {
 	return `screwdriver-escape-${basename(vaultPath)}.txt`;
@@ -20,7 +24,7 @@ function restoreNote(unsafePath: string): string {
 	return `---
 adjustObsidianDir: true
 skipNewFile: false
-skipOldFile: false
+skipOldFile: true
 ---
 
 \`\`\`screwdriver:${unsafePath}:plain:0
@@ -29,6 +33,18 @@ unsafe content
 
 \`\`\`screwdriver:${SAFE_PATH}:plain:0
 safe content
+\`\`\`
+
+\`\`\`screwdriver:${SIBLING_PATH}:plain:0
+sibling content
+\`\`\`
+
+\`\`\`screwdriver:${BINARY_PATH}:bin:0
+AAEC/w==
+\`\`\`
+
+\`\`\`screwdriver:${SKIPPED_PATH}:plain:0
+replacement content
 \`\`\`
 `;
 }
@@ -88,6 +104,18 @@ async function verifyRestorePathBoundary(testSession: ScrewDriverTestSession): P
 		if (safeContent !== "safe content") {
 			throw new Error(`Unexpected restored content: ${JSON.stringify(safeContent)}`);
 		}
+		const siblingContent = await readFile(join(testSession.vault.path, SIBLING_PATH), "utf8");
+		if (siblingContent !== "sibling content") {
+			throw new Error(`Unexpected sibling content: ${JSON.stringify(siblingContent)}`);
+		}
+		const binaryContent = await readFile(join(testSession.vault.path, BINARY_PATH));
+		if (!binaryContent.equals(BINARY_CONTENT)) {
+			throw new Error(`Unexpected binary content: ${binaryContent.toString("hex")}`);
+		}
+		const skippedContent = await readFile(join(testSession.vault.path, SKIPPED_PATH), "utf8");
+		if (skippedContent !== "existing content") {
+			throw new Error(`Existing file was overwritten: ${JSON.stringify(skippedContent)}`);
+		}
 		try {
 			await access(outsidePath);
 			throw new Error(`Unsafe restore escaped the Vault: ${outsidePath}`);
@@ -106,11 +134,13 @@ async function main(): Promise<void> {
 		testSession = await startScrewDriverTestSession({
 			prepareVault: async (vault) => {
 				const unsafePath = `../${escapeFilename(vault.path)}`;
+				await mkdir(join(vault.path, "Restored"), { recursive: true });
+				await writeFile(join(vault.path, SKIPPED_PATH), "existing content", "utf8");
 				await writeFile(join(vault.path, EXPORT_NOTE_PATH), restoreNote(unsafePath), "utf8");
 			},
 		});
 		await verifyRestorePathBoundary(testSession);
-		console.log("ScrewDriver safe restore and traversal rejection passed in real Obsidian");
+		console.log("ScrewDriver text, binary, skip, and traversal restore checks passed in real Obsidian");
 	} finally {
 		if (testSession) await stopScrewDriverTestSession(testSession);
 	}

--- a/test/e2e-obsidian/restore-paths.mts
+++ b/test/e2e-obsidian/restore-paths.mts
@@ -83,7 +83,7 @@ async function verifyRestorePathBoundary(testSession: ScrewDriverTestSession): P
 				timeout: 10_000,
 			});
 			await page.waitForFunction(
-				async (safePath) => {
+				async (expectedPaths) => {
 					const obsidianApp = (
 						globalThis as typeof globalThis & {
 							app?: {
@@ -93,11 +93,17 @@ async function verifyRestorePathBoundary(testSession: ScrewDriverTestSession): P
 							};
 						}
 					).app;
-					return await obsidianApp?.vault?.adapter?.exists(safePath) === true;
+					const adapter = obsidianApp?.vault?.adapter;
+					if (!adapter) return false;
+					return (await Promise.all(expectedPaths.map((path) => adapter.exists(path))))
+						.every((exists) => exists);
 				},
-				SAFE_PATH,
+				[SAFE_PATH, SIBLING_PATH, BINARY_PATH],
 				{ timeout: 10_000 },
 			);
+			await page.locator(".notice")
+				.filter({ hasText: `File:${SKIPPED_PATH} is already up to date.` })
+				.waitFor({ state: "visible", timeout: 10_000 });
 		});
 
 		const safeContent = await readFile(join(testSession.vault.path, SAFE_PATH), "utf8");

--- a/tests/vault-restore.test.ts
+++ b/tests/vault-restore.test.ts
@@ -1,0 +1,234 @@
+import type { Vault } from "obsidian";
+import { describe, expect, it } from "vitest";
+import {
+	createObsidianVaultRestoreAccess,
+	restoreVaultFile,
+	type VaultRestoreAccess,
+	type VaultRestoreRequest,
+} from "../vault-restore";
+
+function request(overrides: Partial<VaultRestoreRequest> = {}): VaultRestoreRequest {
+	return {
+		path: "folder/file.txt",
+		createPayload: () => ({ kind: "text", data: "content" }),
+		storedMtime: 20,
+		skipOldFile: false,
+		skipNewFile: false,
+		...overrides,
+	};
+}
+
+function createRestoreAccess(statMtime: number | null = null) {
+	const transcript: string[] = [];
+	const vault: VaultRestoreAccess = {
+		stat(path) {
+			transcript.push(`stat:${path}`);
+			return Promise.resolve(statMtime === null ? null : { mtime: statMtime });
+		},
+		ensureParentDirectories(path) {
+			transcript.push(`ensure:${path}`);
+			return Promise.resolve();
+		},
+		writeText(path, data) {
+			transcript.push(`writeText:${path}:${data}`);
+			return Promise.resolve();
+		},
+		writeBinary(path, data) {
+			transcript.push(`writeBinary:${path}:${Array.from(new Uint8Array(data)).join(",")}`);
+			return Promise.resolve();
+		},
+	};
+	return { transcript, vault };
+}
+
+describe("restoreVaultFile", () => {
+	it("writes a missing text file after ensuring its parent", async () => {
+		const access = createRestoreAccess();
+		await expect(restoreVaultFile(access.vault, request())).resolves.toBe("written");
+		expect(access.transcript).toEqual([
+			"stat:folder/file.txt",
+			"ensure:folder/file.txt",
+			"writeText:folder/file.txt:content",
+		]);
+	});
+
+	it("forwards the exact binary view", async () => {
+		const access = createRestoreAccess();
+		const allocation = new Uint8Array([9, 1, 2, 3, 9]);
+		const data = allocation.buffer.slice(1, 4);
+		await restoreVaultFile(access.vault, request({
+			path: "folder/file.bin",
+			createPayload: () => ({ kind: "binary", data }),
+		}));
+		expect(access.transcript).toEqual([
+			"stat:folder/file.bin",
+			"ensure:folder/file.bin",
+			"writeBinary:folder/file.bin:1,2,3",
+		]);
+	});
+
+	it.each([
+		{ storedMtime: 19, currentMtime: 20, expected: "skipped-up-to-date" as const },
+		{ storedMtime: 20, currentMtime: 20, expected: "skipped-existing" as const },
+		{ storedMtime: 21, currentMtime: 20, expected: "skipped-existing" as const },
+	])("preserves the skip boundary for $storedMtime against $currentMtime", async ({
+		storedMtime,
+		currentMtime,
+		expected,
+	}) => {
+		const access = createRestoreAccess(currentMtime);
+		await expect(restoreVaultFile(access.vault, request({
+			storedMtime,
+			skipOldFile: true,
+			skipNewFile: true,
+		}))).resolves.toBe(expected);
+		expect(access.transcript).toEqual(["stat:folder/file.txt"]);
+	});
+
+	it("does not decode payload for a skipped file", async () => {
+		const access = createRestoreAccess(20);
+		let payloadCreated = false;
+		await expect(restoreVaultFile(access.vault, request({
+			storedMtime: 19,
+			skipOldFile: true,
+			createPayload() {
+				payloadCreated = true;
+				throw new Error("payload should not be created");
+			},
+		}))).resolves.toBe("skipped-up-to-date");
+		expect(payloadCreated).toBe(false);
+	});
+
+	it("does not prepare directories when payload decoding fails", async () => {
+		const access = createRestoreAccess();
+		await expect(restoreVaultFile(access.vault, request({
+			createPayload() {
+				throw new Error("decode failed");
+			},
+		}))).rejects.toThrow("decode failed");
+		expect(access.transcript).toEqual(["stat:folder/file.txt"]);
+	});
+
+	it.each([
+		{ storedMtime: 20, currentMtime: 20, skipOldFile: true, skipNewFile: false },
+		{ storedMtime: 19, currentMtime: 20, skipOldFile: false, skipNewFile: true },
+	])("writes across the non-skipping boundary %#", async ({
+		storedMtime,
+		currentMtime,
+		skipOldFile,
+		skipNewFile,
+	}) => {
+		const access = createRestoreAccess(currentMtime);
+		await expect(restoreVaultFile(access.vault, request({
+			storedMtime,
+			skipOldFile,
+			skipNewFile,
+		}))).resolves.toBe("written");
+		expect(access.transcript).toHaveLength(3);
+	});
+
+	it("preserves overwrite behaviour for an invalid stored modification time", async () => {
+		const access = createRestoreAccess(20);
+		await expect(restoreVaultFile(access.vault, request({
+			storedMtime: Number.NaN,
+			skipOldFile: true,
+			skipNewFile: true,
+		}))).resolves.toBe("written");
+		expect(access.transcript).toHaveLength(3);
+	});
+
+	it("does not continue after parent preparation fails", async () => {
+		const access = createRestoreAccess();
+		access.vault.ensureParentDirectories = () => Promise.reject(new Error("mkdir failed"));
+		await expect(restoreVaultFile(access.vault, request())).rejects.toThrow("mkdir failed");
+		expect(access.transcript).toEqual(["stat:folder/file.txt"]);
+	});
+
+	it("propagates write failures", async () => {
+		const access = createRestoreAccess();
+		access.vault.writeText = () => Promise.reject(new Error("write failed"));
+		await expect(restoreVaultFile(access.vault, request())).rejects.toThrow("write failed");
+		expect(access.transcript).toEqual([
+			"stat:folder/file.txt",
+			"ensure:folder/file.txt",
+		]);
+	});
+});
+
+describe("createObsidianVaultRestoreAccess", () => {
+	it("ensures shared nested parents once and root-level files without directory work", async () => {
+		const transcript: string[] = [];
+		const folders = new Set<string>();
+		const vault = {
+			adapter: {
+				stat(path: string) {
+					transcript.push(`stat:${path}`);
+					return Promise.resolve(folders.has(path)
+						? { ctime: 0, mtime: 0, size: 0, type: "folder" as const }
+						: null);
+				},
+				write(path: string) {
+					transcript.push(`write:${path}`);
+					return Promise.resolve();
+				},
+				writeBinary() {
+					return Promise.resolve();
+				},
+			},
+			createFolder(path: string) {
+				transcript.push(`mkdir:${path}`);
+				folders.add(path);
+				return Promise.resolve({});
+			},
+		} as unknown as Vault;
+		const access = createObsidianVaultRestoreAccess(vault);
+
+		await access.ensureParentDirectories("one/two/a.txt");
+		await access.ensureParentDirectories("one/two/b.txt");
+		await access.ensureParentDirectories("root.txt");
+
+		expect(transcript).toEqual([
+			"stat:one",
+			"mkdir:one",
+			"stat:one/two",
+			"mkdir:one/two",
+		]);
+	});
+
+	it("accepts a folder created concurrently without inspecting error text", async () => {
+		let statCalls = 0;
+		const vault = {
+			adapter: {
+				stat() {
+					statCalls += 1;
+					return Promise.resolve(statCalls === 1
+						? null
+						: { ctime: 0, mtime: 0, size: 0, type: "folder" as const });
+				},
+				write() { return Promise.resolve(); },
+				writeBinary() { return Promise.resolve(); },
+			},
+			createFolder() { return Promise.reject(new Error("localised concurrent error")); },
+		} as unknown as Vault;
+
+		await expect(createObsidianVaultRestoreAccess(vault)
+			.ensureParentDirectories("folder/file.txt")).resolves.toBeUndefined();
+	});
+
+	it("rejects a parent occupied by a file", async () => {
+		const vault = {
+			adapter: {
+				stat() {
+					return Promise.resolve({ ctime: 0, mtime: 0, size: 1, type: "file" as const });
+				},
+				write() { return Promise.resolve(); },
+				writeBinary() { return Promise.resolve(); },
+			},
+			createFolder() { return Promise.resolve({}); },
+		} as unknown as Vault;
+
+		await expect(createObsidianVaultRestoreAccess(vault)
+			.ensureParentDirectories("folder/file.txt"))
+			.rejects.toThrow("Restore parent is not a folder: folder");
+	});
+});

--- a/vault-restore.ts
+++ b/vault-restore.ts
@@ -1,0 +1,102 @@
+import type { Vault } from "obsidian";
+
+/** Metadata required by ScrewDriver's restore overwrite policy. */
+export interface VaultRestoreStat {
+	readonly mtime: number;
+}
+
+/** Root-bound operations required to restore one file into the active Vault. */
+export interface VaultRestoreAccess {
+	stat(path: string): Promise<VaultRestoreStat | null>;
+	ensureParentDirectories(path: string): Promise<void>;
+	writeText(path: string, data: string): Promise<void>;
+	writeBinary(path: string, data: ArrayBuffer): Promise<void>;
+}
+
+export type VaultRestorePayload =
+	| { readonly kind: "text"; readonly data: string }
+	| { readonly kind: "binary"; readonly data: ArrayBuffer };
+
+export interface VaultRestoreRequest {
+	readonly path: string;
+	readonly createPayload: () => VaultRestorePayload;
+	readonly storedMtime: number;
+	readonly skipOldFile: boolean;
+	readonly skipNewFile: boolean;
+}
+
+export type VaultRestoreResult = "written" | "skipped-up-to-date" | "skipped-existing";
+
+/** Applies ScrewDriver's best-effort overwrite policy and restores one file. */
+export async function restoreVaultFile(
+	vault: VaultRestoreAccess,
+	request: VaultRestoreRequest,
+): Promise<VaultRestoreResult> {
+	const current = await vault.stat(request.path);
+	if (current !== null) {
+		if (request.skipOldFile && request.storedMtime < current.mtime) {
+			return "skipped-up-to-date";
+		}
+		if (request.skipNewFile && request.storedMtime >= current.mtime) {
+			return "skipped-existing";
+		}
+	}
+
+	const payload = request.createPayload();
+	await vault.ensureParentDirectories(request.path);
+	if (payload.kind === "text") {
+		await vault.writeText(request.path, payload.data);
+	} else {
+		await vault.writeBinary(request.path, payload.data);
+	}
+	return "written";
+}
+
+/**
+ * Creates a restore adapter bound to one Obsidian Vault.
+ *
+ * The successful-directory cache is scoped to this adapter instance. Create one
+ * adapter for each restore operation so sibling files reuse parent checks while
+ * later operations still observe external Vault changes.
+ */
+export function createObsidianVaultRestoreAccess(vault: Vault): VaultRestoreAccess {
+	const ensuredDirectories = new Set<string>();
+
+	async function ensureDirectory(path: string): Promise<void> {
+		if (ensuredDirectories.has(path)) return;
+
+		const current = await vault.adapter.stat(path);
+		if (current !== null) {
+			if (current.type !== "folder") {
+				throw new Error(`Restore parent is not a folder: ${path}`);
+			}
+			ensuredDirectories.add(path);
+			return;
+		}
+
+		try {
+			await vault.createFolder(path);
+		} catch (error) {
+			// A concurrent creator may have won after the metadata check. Confirm
+			// the resulting state rather than depending on Obsidian's error text.
+			const afterCreate = await vault.adapter.stat(path);
+			if (afterCreate?.type !== "folder") throw error;
+		}
+		ensuredDirectories.add(path);
+	}
+
+	return {
+		stat: (path) => vault.adapter.stat(path),
+		async ensureParentDirectories(path) {
+			const parts = path.split("/");
+			parts.pop();
+			let parent = "";
+			for (const part of parts) {
+				parent = parent === "" ? part : `${parent}/${part}`;
+				await ensureDirectory(parent);
+			}
+		},
+		writeText: (path, data) => vault.adapter.write(path, data),
+		writeBinary: (path, data) => vault.adapter.writeBinary(path, data),
+	};
+}


### PR DESCRIPTION
## Summary

- extract ScrewDriver's restore workflow behind root-bound metadata, parent-directory, text-upsert, and binary-upsert capabilities;
- create one Obsidian Vault adapter for each restore command so sibling files reuse successful parent-directory checks;
- replace the exact English `Folder already exists.` error check with structural folder-state confirmation;
- stop the affected write when parent-directory preparation fails;
- preserve the existing `stat` → skip → decode → directory → write order and modification-time comparisons; and
- expand App-free and local real-Obsidian restore coverage.

## Why

Restore logic previously mixed `App`, `Vault.createFolder`, and `vault.adapter` operations inside the plug-in command. Each file retried every ancestor folder and used expected exceptions as the ordinary existing-folder path. Non-existing-folder failures displayed a Notice but then continued into deeper creation and the final write, which obscured the first failure.

The local capability boundary makes operation order and failure propagation directly testable without presenting the still-unsettled storage semantics as a neutral Fancy Kit API.

## Impact

Successful restores, text and binary decoding, skip boundaries, invalid stored timestamp behaviour, and user-facing success and skip Notices are preserved. Shared parent folders are checked or created once per restore command. A genuine parent-folder creation failure now fails fast and is reported through the existing per-file write failure Notice instead of continuing with later storage calls.

The modification-time decision remains best-effort rather than atomic. OW path validation remains lexical and does not claim symbolic-link containment. These ScrewDriver-owned capabilities are therefore not yet proposed as a cross-platform storage contract.

## Validation

- [x] `npm run check` — 39 tests passed
- [x] `npm run build`
- [x] `npm run check:e2e:obsidian`
- [x] local real-Obsidian restore scenario
  - nested sibling text files restored;
  - exact binary bytes restored;
  - an existing newer file preserved; and
  - sibling traversal rejected without creating an outside file.
- [x] `git diff --check`

CI continues to type-check the real-Obsidian E2E script without downloading or launching Obsidian.
