### PR TITLE
Use shared Vault frontmatter access

### DIFF
--- a/docs/devs.md
+++ b/docs/devs.md
@@ -48,6 +48,18 @@ npm run test:e2e:obsidian:restore-paths
 
 Real-Obsidian E2E is currently validated on Linux only and is not part of the default CI gate.
 
+## Vault frontmatter boundary
+
+The plug-in creates one path-based `VaultFrontmatterAccess` capability during loading:
+
+```ts
+this.frontmatter = createObsidianVaultFrontmatterAccess(this.app);
+```
+
+`frontmatter-workflow.ts` owns the policy for adding export targets and initialising local-export and remote-fetch note properties. The workflow accepts only `updateFrontmatter`, so App-free tests can use `createVaultFrontmatterTestHarness` to verify the before-and-after values and failure propagation without constructing an Obsidian `App` or `TFile`.
+
+The local real-Obsidian add-target scenario complements those policy tests by exercising Obsidian's frontmatter processor and verifying the persisted note properties.
+
 ## Vault read boundary
 
 `vault-read.ts` defines the narrow, ScrewDriver-owned capabilities used by target discovery and dump capture: direct-child listing, binary reads, and metadata reads. The production composition supplies `app.vault.adapter`, which is already bound to the active Vault root. All paths passed to these helpers remain Vault-relative; the helpers do not select or discover a root.

--- a/frontmatter-workflow.ts
+++ b/frontmatter-workflow.ts
@@ -1,0 +1,60 @@
+import type {
+	VaultFrontmatterAccess,
+} from "@vrtmrz/obsidian-plugin-kit/vault";
+
+/** Frontmatter capability required by ScrewDriver note workflows. */
+export type ScrewDriverFrontmatterAccess = Pick<
+	VaultFrontmatterAccess,
+	"updateFrontmatter"
+>;
+
+function appendUnique(current: unknown, additions: readonly string[]): unknown[] {
+	return [...new Set([...((current ?? []) as unknown[]), ...additions])];
+}
+
+/** Adds one export target and its optional filters to an existing note. */
+export async function addExportTarget(
+	frontmatter: ScrewDriverFrontmatterAccess,
+	notePath: string,
+	target: string,
+	filters: readonly string[],
+): Promise<void> {
+	await frontmatter.updateFrontmatter(notePath, (value) => {
+		value.targets = appendUnique(value.targets, [target]);
+		if (filters.length > 0) {
+			value.filters = appendUnique(value.filters, filters);
+		}
+	});
+}
+
+/** Initialises missing local-export properties without replacing existing values. */
+export async function initialiseLocalExportNote(
+	frontmatter: ScrewDriverFrontmatterAccess,
+	notePath: string,
+): Promise<void> {
+	await frontmatter.updateFrontmatter(notePath, (value) => {
+		value.targets = value.targets ?? [];
+		value.ignores = value.ignores ?? ["/node_modules", "/.git"];
+		value.filters = value.filters ?? [];
+		value.comment = value.comment ?? "Use 'Add folder to this export note' to add targets";
+		value.tags = value.tags ?? [];
+		value.adjustObsidianDir = value.adjustObsidianDir ?? true;
+		value.skipNewFile = value.skipNewFile ?? false;
+		value.skipOldFile = value.skipOldFile ?? false;
+	});
+}
+
+/** Initialises missing remote-fetch properties without replacing existing values. */
+export async function initialiseRemoteFetchNote(
+	frontmatter: ScrewDriverFrontmatterAccess,
+	notePath: string,
+): Promise<void> {
+	await frontmatter.updateFrontmatter(notePath, (value) => {
+		value.urls = value.urls ?? [];
+		value.authorization = value.authorization ?? "";
+		value.tags = value.tags ?? [];
+		value.header_json = value.header_json ?? "";
+		value.skipNewFile = value.skipNewFile ?? false;
+		value.skipOldFile = value.skipOldFile ?? false;
+	});
+}

--- a/main.ts
+++ b/main.ts
@@ -1,9 +1,18 @@
 import { createObsidianUi, type UiInteractions } from "@vrtmrz/obsidian-plugin-kit/ui";
+import {
+	createObsidianVaultFrontmatterAccess,
+	type VaultFrontmatterAccess,
+} from "@vrtmrz/obsidian-plugin-kit/vault";
 import { UnsafePathError } from "octagonal-wheels/path";
 import { Editor, MarkdownView, Notice, parseYaml, Plugin, requestUrl, arrayBufferToBase64, base64ToArrayBuffer, MarkdownRenderer, TFile, type MarkdownFileInfo, MarkdownRenderChild } from "obsidian";
 import { PORTABLE_OBSIDIAN_CONFIG_DIR, resolveRestorePath } from "./restore-path";
 import { chooseTargetDirectory, shouldIncludePluginData } from "./ui-workflow";
 import { createObsidianVaultRestoreAccess, restoreVaultFile } from "./vault-restore";
+import {
+	addExportTarget,
+	initialiseLocalExportNote,
+	initialiseRemoteFetchNote,
+} from "./frontmatter-workflow";
 import {
 	listVaultDirectoriesRecursively,
 	listVaultFilesRecursively,
@@ -28,9 +37,11 @@ function isPlainText(filename: string): boolean {
 
 export default class ScrewDriverPlugin extends Plugin {
 	ui!: UiInteractions;
+	frontmatter!: VaultFrontmatterAccess;
 
 	onload() {
 		this.ui = createObsidianUi(this.app);
+		this.frontmatter = createObsidianVaultFrontmatterAccess(this.app);
 		void this.loadSettings();
 		this.addCommand({
 			id: "screwdriver-add-target-dir",
@@ -60,51 +71,30 @@ export default class ScrewDriverPlugin extends Plugin {
 						new Notice("Current file is not a valid file.");
 						return;
 					}
-					void this.app.fileManager.processFrontMatter(view.file, fm => {
-						fm.targets = [...new Set([...fm.targets ?? [], selected])];
-						if (filters.length > 0) {
-							fm.filters = [...new Set([...(fm.filters ?? []), ...filters])]
-						}
-					})
+					await addExportTarget(this.frontmatter, view.file.path, selected, filters);
 				}
 			}
 		});
 		this.addCommand({
 			id: "screwdriver-create-template-dump",
 			name: "Create local export note",
-			editorCallback: (_editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
+			editorCallback: async (_editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				if (!(view.file instanceof TFile)) {
 					new Notice("Current file is not a valid file.");
 					return;
 				}
-				void this.app.fileManager.processFrontMatter(view.file, fn => {
-					fn.targets = fn.targets ?? [];
-					fn.ignores = fn.ignores ?? ["/node_modules", "/.git"];
-					fn.filters = fn.filters ?? [];
-					fn.comment = fn.comment ?? "Use 'Add folder to this export note' to add targets";
-					fn.tags = fn.tags ?? [];
-					fn.adjustObsidianDir = fn.adjustObsidianDir ?? true;
-					fn.skipNewFile = fn.skipNewFile ?? false;
-					fn.skipOldFile = fn.skipOldFile ?? false;
-				});
+				await initialiseLocalExportNote(this.frontmatter, view.file.path);
 			},
 		});
 		this.addCommand({
 			id: "screwdriver-create-template-fetch",
 			name: "Create remote fetch note",
-			editorCallback: (_editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
+			editorCallback: async (_editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				if (!(view.file instanceof TFile)) {
 					new Notice("Current file is not a valid file.");
 					return;
 				}
-				void this.app.fileManager.processFrontMatter(view.file, fn => {
-					fn.urls = fn.urls ?? [];
-					fn.authorization = fn.authorization ?? "";
-					fn.tags = fn.tags ?? [];
-					fn.header_json = fn.header_json ?? "";
-					fn.skipNewFile = fn.skipNewFile ?? false;
-					fn.skipOldFile = fn.skipOldFile ?? false;
-				});
+				await initialiseRemoteFetchNote(this.frontmatter, view.file.path);
 			},
 		})
 		// This adds an editor command that can perform some operation on the current editor instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.12",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/obsidian-plugin-kit": "0.1.0",
+				"@vrtmrz/obsidian-plugin-kit": "0.1.1-rc.0",
 				"@vrtmrz/ui-interactions": "0.1.0",
 				"octagonal-wheels": "0.1.48"
 			},
@@ -1617,9 +1617,9 @@
 			}
 		},
 		"node_modules/@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
-			"integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
+			"version": "0.1.1-rc.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1-rc.0.tgz",
+			"integrity": "sha512-MoLPwWDq1CT6y4yv/My0FPhKEJUkbh2b8KKpvPqZIxK2Wt3zfCYuuT4MHsDD7W1514CKJ0FAz/+y3vNO4K7g7g==",
 			"license": "MIT",
 			"dependencies": {
 				"@vrtmrz/ui-interactions": "0.1.0"
@@ -7301,9 +7301,9 @@
 			}
 		},
 		"@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
-			"integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
+			"version": "0.1.1-rc.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1-rc.0.tgz",
+			"integrity": "sha512-MoLPwWDq1CT6y4yv/My0FPhKEJUkbh2b8KKpvPqZIxK2Wt3zfCYuuT4MHsDD7W1514CKJ0FAz/+y3vNO4K7g7g==",
 			"requires": {
 				"@vrtmrz/ui-interactions": "0.1.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.12",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/obsidian-plugin-kit": "0.1.1-rc.0",
+				"@vrtmrz/obsidian-plugin-kit": "0.1.1",
 				"@vrtmrz/ui-interactions": "0.1.0",
 				"octagonal-wheels": "0.1.48"
 			},
@@ -1617,9 +1617,9 @@
 			}
 		},
 		"node_modules/@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.1.1-rc.0",
-			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1-rc.0.tgz",
-			"integrity": "sha512-MoLPwWDq1CT6y4yv/My0FPhKEJUkbh2b8KKpvPqZIxK2Wt3zfCYuuT4MHsDD7W1514CKJ0FAz/+y3vNO4K7g7g==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1.tgz",
+			"integrity": "sha512-I7Ag9/+LuMIkN/JLM/m9GrzTBY2pHbhu15cdmErBapiqJ7UKNboKJKKOOhpM/Sq5vJpRKxiYD8Ib13xi64J9HQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@vrtmrz/ui-interactions": "0.1.0"
@@ -7301,9 +7301,9 @@
 			}
 		},
 		"@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.1.1-rc.0",
-			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1-rc.0.tgz",
-			"integrity": "sha512-MoLPwWDq1CT6y4yv/My0FPhKEJUkbh2b8KKpvPqZIxK2Wt3zfCYuuT4MHsDD7W1514CKJ0FAz/+y3vNO4K7g7g==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1.tgz",
+			"integrity": "sha512-I7Ag9/+LuMIkN/JLM/m9GrzTBY2pHbhu15cdmErBapiqJ7UKNboKJKKOOhpM/Sq5vJpRKxiYD8Ib13xi64J9HQ==",
 			"requires": {
 				"@vrtmrz/ui-interactions": "0.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@vrtmrz/obsidian-plugin-kit": "0.1.0",
+		"@vrtmrz/obsidian-plugin-kit": "0.1.1-rc.0",
 		"@vrtmrz/ui-interactions": "0.1.0",
 		"octagonal-wheels": "0.1.48"
 	}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@vrtmrz/obsidian-plugin-kit": "0.1.1-rc.0",
+		"@vrtmrz/obsidian-plugin-kit": "0.1.1",
 		"@vrtmrz/ui-interactions": "0.1.0",
 		"octagonal-wheels": "0.1.48"
 	}

--- a/tests/frontmatter-workflow.test.ts
+++ b/tests/frontmatter-workflow.test.ts
@@ -1,0 +1,103 @@
+import { createVaultFrontmatterTestHarness } from "@vrtmrz/obsidian-plugin-kit/testing";
+import { describe, expect, it } from "vitest";
+import {
+	addExportTarget,
+	initialiseLocalExportNote,
+	initialiseRemoteFetchNote,
+} from "../frontmatter-workflow";
+
+describe("ScrewDriver frontmatter workflows", () => {
+	it("adds a target and filters once through the shared capability", async () => {
+		const harness = createVaultFrontmatterTestHarness({
+			files: {
+				"Export.md": {
+					targets: ["existing", "selected"],
+					filters: ["main\\.js$"],
+				},
+			},
+		});
+
+		await addExportTarget(
+			harness.vault,
+			"Export.md",
+			"selected",
+			["main\\.js$", "manifest\\.json$"],
+		);
+
+		expect(harness.transcript).toEqual([
+			{
+				kind: "updateFrontmatter",
+				path: "Export.md",
+				before: {
+					targets: ["existing", "selected"],
+					filters: ["main\\.js$"],
+				},
+				after: {
+					targets: ["existing", "selected"],
+					filters: ["main\\.js$", "manifest\\.json$"],
+				},
+			},
+		]);
+	});
+
+	it("leaves filters untouched when the selected target has none", async () => {
+		const harness = createVaultFrontmatterTestHarness({
+			files: { "Export.md": { filters: ["existing"] } },
+		});
+
+		await addExportTarget(harness.vault, "Export.md", "Notes", []);
+
+		expect(harness.getFrontmatter("Export.md")).toEqual({
+			filters: ["existing"],
+			targets: ["Notes"],
+		});
+	});
+
+	it("initialises only missing local-export properties", async () => {
+		const harness = createVaultFrontmatterTestHarness({
+			files: {
+				"Export.md": {
+					targets: ["existing"],
+					comment: "Keep this comment",
+					adjustObsidianDir: false,
+				},
+			},
+		});
+
+		await initialiseLocalExportNote(harness.vault, "Export.md");
+
+		expect(harness.getFrontmatter("Export.md")).toEqual({
+			targets: ["existing"],
+			ignores: ["/node_modules", "/.git"],
+			filters: [],
+			comment: "Keep this comment",
+			tags: [],
+			adjustObsidianDir: false,
+			skipNewFile: false,
+			skipOldFile: false,
+		});
+	});
+
+	it("initialises only missing remote-fetch properties", async () => {
+		const harness = createVaultFrontmatterTestHarness({
+			files: {
+				"Fetch.md": {
+					urls: ["https://example.com/archive.md"],
+					authorization: "existing",
+					skipOldFile: true,
+				},
+			},
+		});
+
+		await initialiseRemoteFetchNote(harness.vault, "Fetch.md");
+
+		expect(harness.getFrontmatter("Fetch.md")).toEqual({
+			urls: ["https://example.com/archive.md"],
+			authorization: "existing",
+			tags: [],
+			header_json: "",
+			skipNewFile: false,
+			skipOldFile: true,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Route export-target updates and local/remote note initialisation through Fancy Kit's path-based `VaultFrontmatterAccess`.
- Move ScrewDriver's frontmatter policy into an App-free workflow module.
- Add harness tests for target/filter merging and property initialisation.
- Pin the exact stable `@vrtmrz/obsidian-plugin-kit@0.1.1` registry release.

## Impact

There is no intentional user-visible behaviour change. The same target, filter, and default-property values are written through the shared adapter. The boundary makes the policy directly testable without constructing an Obsidian `App` or `TFile`.

## Package validation

The public release candidate was exercised before `0.1.1` was published. This branch now resolves the exact stable registry tarball and its recorded integrity, rather than a local package or repository checkout.

- `@vrtmrz/obsidian-plugin-kit@0.1.1`
- published shasum: `af2e2f493be5cd7a6208b3ed2b9b87761d2dceec`

## Validation

- `npm run check`
  - lint passed
  - 43 tests across five files passed
  - TypeScript check passed
- `npm run build`
- `npm run check:e2e:obsidian`
- `npm run test:e2e:obsidian:add-target`
  - target selection and confirmation passed with the stable package in a real Obsidian instance on Linux

The updated branch CI provides the clean-install remote gate for the stable dependency.
