### PR TITLE
Automate the release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/finalise-release.yml
+++ b/.github/workflows/finalise-release.yml
@@ -1,0 +1,94 @@
+name: Finalise Release Tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version, for example 0.0.13
+        required: true
+        type: string
+      release_branch:
+        description: Release PR branch. Defaults to release/<version>.
+        required: false
+        type: string
+      expected_head_sha:
+        description: Full head commit SHA reviewed in the release PR
+        required: true
+        type: string
+
+jobs:
+  finalise:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      actions: write
+      contents: write
+
+    steps:
+      - name: Resolve release branch
+        id: branch
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASE_BRANCH_INPUT: ${{ inputs.release_branch }}
+        run: |
+          set -euo pipefail
+          BRANCH="${RELEASE_BRANCH_INPUT}"
+          if [[ -z "${BRANCH}" ]]; then
+            BRANCH="release/${VERSION}"
+          fi
+          git check-ref-format --branch "${BRANCH}"
+          echo "name=${BRANCH}" >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.name }}
+          fetch-depth: 0
+
+      - name: Validate release head
+        env:
+          VERSION: ${{ inputs.version }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+        run: |
+          set -euo pipefail
+          ACTUAL_HEAD_SHA="$(git rev-parse HEAD)"
+          if [[ "${ACTUAL_HEAD_SHA}" != "${EXPECTED_HEAD_SHA}" ]]; then
+            echo "Release branch head is ${ACTUAL_HEAD_SHA}, expected ${EXPECTED_HEAD_SHA}." >&2
+            exit 1
+          fi
+          node release-process.mjs validate "${VERSION}"
+          git fetch --tags --force
+          if git rev-parse --verify --quiet "refs/tags/${VERSION}" >/dev/null; then
+            echo "Release tag already exists: ${VERSION}" >&2
+            exit 1
+          fi
+
+      - name: Create and push release tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git tag "${VERSION}"
+          git push origin "${VERSION}"
+
+      - name: Dispatch release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml \
+            --ref "${VERSION}" \
+            --field tag="${VERSION}" \
+            --field draft=true \
+            --field prerelease=false
+
+      - name: Summarise next steps
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "Created tag \`${VERSION}\` and explicitly dispatched the release workflow."
+            echo ""
+            echo "Approve the release environment, inspect and publish the draft GitHub Release, then validate it with BRAT."
+            echo "Keep the release pull request in draft until BRAT succeeds, then merge it with a merge commit."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,130 @@
+name: Prepare Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version, for example 0.0.13
+        required: true
+        type: string
+      release_branch:
+        description: Release branch name. Defaults to release/<version>.
+        required: false
+        type: string
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare release changes
+        id: prepare
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASE_BRANCH_INPUT: ${{ inputs.release_branch }}
+        run: |
+          set -euo pipefail
+          node release-process.mjs input "${VERSION}"
+
+          BRANCH="${RELEASE_BRANCH_INPUT}"
+          if [[ -z "${BRANCH}" ]]; then
+            BRANCH="release/${VERSION}"
+          fi
+          git check-ref-format --branch "${BRANCH}"
+
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "Release branch already exists: ${BRANCH}" >&2
+            exit 1
+          fi
+          git fetch --tags --force
+          if git rev-parse --verify --quiet "refs/tags/${VERSION}" >/dev/null; then
+            echo "Release tag already exists: ${VERSION}" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "${BRANCH}"
+          npm version "${VERSION}" --no-git-tag-version
+          node release-process.mjs prepare "${VERSION}"
+          npm run check
+          npm run build
+          npm run check:e2e:obsidian
+
+          RELEASE_FILES=(package.json package-lock.json manifest.json versions.json)
+          if [[ -f updates.md ]]; then
+            RELEASE_FILES+=(updates.md)
+          fi
+          git add "${RELEASE_FILES[@]}"
+          git diff --cached --check
+          if git diff --cached --quiet; then
+            echo "Release preparation produced no tracked changes" >&2
+            exit 1
+          fi
+          git commit -m "${VERSION}"
+          git push --set-upstream origin "${BRANCH}"
+
+          echo "branch=${BRANCH}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create draft release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          RELEASE_BRANCH: ${{ steps.prepare.outputs.branch }}
+        run: |
+          cat > /tmp/release-pr-body.md <<EOF
+          > [!IMPORTANT]
+          > **Merge intentionally on hold**
+          >
+          > Keep this pull request in draft, and leave `main` on the previous release, until the published build has passed BRAT validation.
+
+          ## Release checklist
+
+          - [ ] Review the release changes and prepare the GitHub Release notes
+          - [ ] Confirm `package.json`, `manifest.json`, and `versions.json` use `${VERSION}`
+          - [ ] Confirm CI has passed
+          - [ ] Run `Finalise Release Tags` with this pull request's fixed head SHA
+          - [ ] Approve `Finalise Release Tags` for the `release` environment to create the fixed tag
+          - [ ] Approve `Release Obsidian Plugin` for the `release` environment
+          - [ ] Inspect the draft GitHub Release and its assets
+          - [ ] Publish the GitHub Release as the latest stable release while keeping this pull request in draft
+          - [ ] Validate the published release with BRAT
+          - [ ] Mark this pull request ready and merge it with a merge commit
+
+          If BRAT validation fails, do not move the published tag. Keep this pull request in draft and prepare a new patch release.
+          EOF
+
+          gh pr create \
+            --base main \
+            --head "${RELEASE_BRANCH}" \
+            --draft \
+            --title "${VERSION}" \
+            --body-file /tmp/release-pr-body.md
+
+      - name: Dispatch CI for release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: ${{ steps.prepare.outputs.branch }}
+        run: gh workflow run ci.yml --ref "${RELEASE_BRANCH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,29 @@
 name: Release Obsidian Plugin
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
-    - '*' # Push events to matching any tag format, i.e. 1.0, 20.15.10
+      - '*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build
+        required: true
+        type: string
+      draft:
+        description: Create the GitHub Release as a draft
+        required: false
+        type: boolean
+        default: true
+      prerelease:
+        description: Mark the GitHub Release as a pre-release
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       id-token: write
@@ -16,24 +31,35 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+        fetch-depth: 0
         submodules: recursive
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '24.x' # You might need to adjust this value to your own version
-    # Get the version number and put it in a variable
+        node-version: '24.x'
     - name: Get Version
       id: version
       run: |
-        echo "tag=$(git describe --abbrev=0 --tags)" >> $GITHUB_OUTPUT
-    # Build the plugin
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          TAG="${{ inputs.tag }}"
+          DRAFT="${{ inputs.draft }}"
+          PRERELEASE="${{ inputs.prerelease }}"
+        else
+          TAG="${GITHUB_REF_NAME}"
+          DRAFT="true"
+          PRERELEASE="false"
+        fi
+        echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+        echo "draft=${DRAFT}" >> "${GITHUB_OUTPUT}"
+        echo "prerelease=${PRERELEASE}" >> "${GITHUB_OUTPUT}"
+    - name: Validate release files
+      run: node release-process.mjs validate "${{ steps.version.outputs.tag }}"
     - name: Build
       id: build
       run: |
         npm ci
         npm run build --if-present
-    # Attest
     - name: Attest Plugin Artifacts
       uses: actions/attest-build-provenance@v4
       with:
@@ -41,7 +67,6 @@ jobs:
               main.js
               manifest.json
               styles.css
-    # Package the required files into a zip
     - name: Package
       run: |
         mkdir ${{ github.event.repository.name }}
@@ -57,4 +82,5 @@ jobs:
           styles.css
         name: ${{ steps.version.outputs.tag }}
         tag_name: ${{ steps.version.outputs.tag }}
-        draft: true
+        draft: ${{ steps.version.outputs.draft }}
+        prerelease: ${{ steps.version.outputs.prerelease }}

--- a/docs/devs.md
+++ b/docs/devs.md
@@ -83,3 +83,16 @@ Paths parsed from fenced block headers are untrusted input. `restore-path.ts` us
 With `adjustObsidianDir` enabled, a validated `.obsidian/` suffix is resolved below the trusted `vault.configDir`. Other paths remain Vault-relative. Unsafe input is skipped rather than normalised; this prevents absolute paths, parent traversal, backslash variants, empty components, control characters, and portable-invalid names from changing meaning on another platform.
 
 The App-free suite owns the path policy contract. The local real-Obsidian restore scenario verifies that a safe block is written inside the isolated Vault while an unsafe sibling traversal is not written outside it.
+
+## Release process
+
+The repository uses three manually gated workflows. Configure the GitHub `release` environment with a required reviewer before using them.
+
+1. Run `Prepare Release PR` with the target version. It checks out `main`, runs the locked build and test gate, updates `package.json`, `manifest.json`, and `versions.json`, pushes `release/<version>`, opens a draft pull request, and explicitly dispatches CI for the release branch. Explicit dispatch is required because branch and pull-request events created with `GITHUB_TOKEN` do not start another workflow.
+2. Review the release changes and GitHub Release notes. Keep the pull request in draft and record its full head commit SHA.
+3. Run `Finalise Release Tags` with the version and reviewed SHA, then approve its `release` environment deployment. It validates the exact branch head, creates the tag, and explicitly dispatches `Release Obsidian Plugin`. Explicit dispatch is required because a tag pushed with `GITHUB_TOKEN` does not start a tag-push workflow.
+4. Approve the separate `Release Obsidian Plugin` deployment to the `release` environment, inspect the draft GitHub Release and its assets, then publish it as the latest stable release while leaving the release pull request in draft.
+5. Install the published build through BRAT and verify start-up, target selection, export, and restore behaviour relevant to the release.
+6. After BRAT succeeds, mark the pull request ready and merge it with a merge commit. A merge commit keeps the tagged release commit in `main` history.
+
+If BRAT validation fails, do not move or replace the published tag. Leave the pull request in draft and prepare a new patch release. If the tag exists but publishing dispatch or build fails, rerun `Release Obsidian Plugin` manually for the existing tag instead of rerunning Finalise.

--- a/release-process.mjs
+++ b/release-process.mjs
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const RELEASE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function assertReleaseVersion(version) {
+	if (!RELEASE_VERSION_PATTERN.test(version)) {
+		throw new Error(`Invalid release version: ${version}`);
+	}
+}
+
+function prepareReleaseNotes(version) {
+	if (!existsSync("updates.md")) return;
+	const content = readFileSync("updates.md", "utf8");
+	const targetHeading = `## ${version}`;
+	if (content.startsWith(`${targetHeading}\n`) || content.startsWith(`${targetHeading}\r\n`)) return;
+	if (!/^## Unreleased\r?$/m.test(content)) {
+		throw new Error("updates.md has no '## Unreleased' section to prepare");
+	}
+	writeFileSync("updates.md", content.replace(/^## Unreleased\r?$/m, targetHeading));
+}
+
+function validateVersionFiles(version) {
+	assertReleaseVersion(version);
+	const packageManifest = readJson("package.json");
+	const pluginManifest = readJson("manifest.json");
+	const versions = readJson("versions.json");
+
+	if (packageManifest.version !== version) {
+		throw new Error(`package.json is ${packageManifest.version}, expected ${version}`);
+	}
+	if (pluginManifest.version !== version) {
+		throw new Error(`manifest.json is ${pluginManifest.version}, expected ${version}`);
+	}
+	if (versions[version] !== pluginManifest.minAppVersion) {
+		throw new Error(`versions.json does not map ${version} to ${pluginManifest.minAppVersion}`);
+	}
+	if (existsSync("updates.md")) {
+		const content = readFileSync("updates.md", "utf8");
+		const firstHeading = content.match(/^## .+$/m)?.[0];
+		if (firstHeading !== `## ${version}`) {
+			throw new Error(`updates.md starts with ${firstHeading ?? "no release heading"}, expected ## ${version}`);
+		}
+	}
+}
+
+const [command, version] = process.argv.slice(2);
+if (!version) throw new Error("Usage: node release-process.mjs <input|prepare|validate> <version>");
+
+if (command === "input") {
+	assertReleaseVersion(version);
+} else if (command === "prepare") {
+	assertReleaseVersion(version);
+	prepareReleaseNotes(version);
+	validateVersionFiles(version);
+} else if (command === "validate") {
+	validateVersionFiles(version);
+} else {
+	throw new Error(`Unknown release-process command: ${command}`);
+}

--- a/tests/release-process.test.ts
+++ b/tests/release-process.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable import/no-nodejs-modules -- Release-process tests exercise Node.js scripts. */
+/// <reference types="node" />
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repositoryRoot = process.cwd();
+const versionBumpScript = join(repositoryRoot, "version-bump.mjs");
+const releaseProcessScript = join(repositoryRoot, "release-process.mjs");
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function createReleaseFixture(version: string): string {
+	const directory = mkdtempSync(join(tmpdir(), "screwdriver-release-"));
+	temporaryDirectories.push(directory);
+	writeFileSync(join(directory, "package.json"), JSON.stringify({ version }));
+	writeFileSync(join(directory, "manifest.json"), JSON.stringify({ version: "0.0.12", minAppVersion: "1.4.4" }));
+	writeFileSync(join(directory, "versions.json"), JSON.stringify({ "0.0.12": "1.4.4" }));
+	return directory;
+}
+
+describe("release version files", () => {
+	it("records every release version even when the minimum app version is unchanged", () => {
+		const version = "0.0.13";
+		const directory = createReleaseFixture(version);
+		execFileSync(process.execPath, [versionBumpScript], {
+			cwd: directory,
+			env: { ...process.env, npm_package_version: version },
+		});
+		execFileSync(process.execPath, [releaseProcessScript, "validate", version], { cwd: directory });
+
+		const versions = JSON.parse(readFileSync(join(directory, "versions.json"), "utf8"));
+		expect(versions[version]).toBe("1.4.4");
+	});
+
+	it("prepares an optional Unreleased section", () => {
+		const version = "0.0.13";
+		const directory = createReleaseFixture(version);
+		execFileSync(process.execPath, [versionBumpScript], {
+			cwd: directory,
+			env: { ...process.env, npm_package_version: version },
+		});
+		writeFileSync(join(directory, "updates.md"), "## Unreleased\n\n- Change\n");
+		execFileSync(process.execPath, [releaseProcessScript, "prepare", version], { cwd: directory });
+
+		expect(readFileSync(join(directory, "updates.md"), "utf8")).toBe("## 0.0.13\n\n- Change\n");
+	});
+});
+
+describe("release workflow contracts", () => {
+	it("holds the generated release PR for BRAT and a merge commit", () => {
+		const workflow = readFileSync(join(repositoryRoot, ".github/workflows/prepare-release.yml"), "utf8");
+		expect(workflow).toContain("Merge intentionally on hold");
+		expect(workflow).toContain("Validate the published release with BRAT");
+		expect(workflow).toContain("merge it with a merge commit");
+		expect(workflow).toContain("gh workflow run ci.yml");
+	});
+
+	it("fixes finalisation to the reviewed head and explicitly dispatches publishing", () => {
+		const workflow = readFileSync(join(repositoryRoot, ".github/workflows/finalise-release.yml"), "utf8");
+		expect(workflow).toContain("expected_head_sha");
+		expect(workflow).toContain("actions: write");
+		expect(workflow).toContain("gh workflow run release.yml");
+	});
+
+	it("supports an explicit tag and draft state in the publishing workflow", () => {
+		const workflow = readFileSync(join(repositoryRoot, ".github/workflows/release.yml"), "utf8");
+		expect(workflow).toContain("tag:");
+		expect(workflow).toContain("draft:");
+		expect(workflow).toContain("prerelease:");
+		expect(workflow).toContain("inputs.tag");
+	});
+});


### PR DESCRIPTION
## Summary

- add manually gated workflows to prepare a release pull request, fix a reviewed commit to a tag, and dispatch the existing release build
- validate release metadata and generated release notes before tagging or publishing
- document the two separate protected-environment approvals, BRAT validation, merge-commit requirement, and recovery procedure
- add contract tests for the release scripts and workflows

## Why

GitHub does not start another workflow from branch, pull-request, or tag events created with `GITHUB_TOKEN`. The release process therefore dispatches CI and publishing explicitly. It also fixes the tag to the exact reviewed pull-request head so that the build tested through BRAT is the commit later retained in `main`.

The pull request remains draft until the infrastructure and repository settings have been reviewed.

## Developer impact

After this pull request is merged, configure a GitHub environment named `release` with a required reviewer, and ensure Actions may create pull requests. A formal release is then prepared through `Prepare Release PR`, finalised against its reviewed full SHA, published as a draft GitHub Release, validated through BRAT, and merged with a merge commit.

## Validation

- `actionlint`
- `npm run check` — 48 tests
- `npm run build`
- `npm run check:e2e:obsidian`
