### PR TITLE
Preserve Markdown in generated release PRs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -94,7 +94,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           RELEASE_BRANCH: ${{ steps.prepare.outputs.branch }}
         run: |
-          cat > /tmp/release-pr-body.md <<EOF
+          cat > /tmp/release-pr-body.md <<'EOF'
           > [!IMPORTANT]
           > **Merge intentionally on hold**
           >
@@ -103,7 +103,7 @@ jobs:
           ## Release checklist
 
           - [ ] Review the release changes and prepare the GitHub Release notes
-          - [ ] Confirm `package.json`, `manifest.json`, and `versions.json` use `${VERSION}`
+          - [ ] Confirm `package.json`, `manifest.json`, and `versions.json` use `__VERSION__`
           - [ ] Confirm CI has passed
           - [ ] Run `Finalise Release Tags` with this pull request's fixed head SHA
           - [ ] Approve `Finalise Release Tags` for the `release` environment to create the fixed tag
@@ -115,6 +115,7 @@ jobs:
 
           If BRAT validation fails, do not move the published tag. Keep this pull request in draft and prepare a new patch release.
           EOF
+          sed -i "s/__VERSION__/${VERSION}/g" /tmp/release-pr-body.md
 
           gh pr create \
             --base main \

--- a/tests/release-process.test.ts
+++ b/tests/release-process.test.ts
@@ -61,6 +61,9 @@ describe("release workflow contracts", () => {
 		expect(workflow).toContain("Validate the published release with BRAT");
 		expect(workflow).toContain("merge it with a merge commit");
 		expect(workflow).toContain("gh workflow run ci.yml");
+		expect(workflow).toContain("<<'EOF'");
+		expect(workflow).toContain('sed -i "s/__VERSION__/${VERSION}/g"');
+		expect(workflow).not.toContain("<<EOF");
 	});
 
 	it("fixes finalisation to the reviewed head and explicitly dispatches publishing", () => {


### PR DESCRIPTION
## Summary

- quote the generated release pull request body heredoc so that Markdown backticks remain literal
- replace only the validated release-version placeholder after the body has been written
- add a contract test that rejects an unquoted heredoc

## Root cause

The first `0.0.13` preparation run interpreted Markdown backticks as shell command substitutions. The release files and explicitly dispatched CI were correct, but identifiers such as `main`, file names, workflow names, and the version disappeared from the generated pull request body.

## Impact

This changes release automation only. It does not change plug-in runtime behaviour. The existing `0.0.13` draft release pull request will be replaced after this fix reaches `main`.

## Validation

- `actionlint`
- `npm run check` — 48 tests
- `git diff --check`
